### PR TITLE
Update SNS Handler with move to sensu org and new version

### DIFF
--- a/pipelines/alert/aws-sns.yaml
+++ b/pipelines/alert/aws-sns.yaml
@@ -41,7 +41,7 @@
 #      plugin documentation for more details.
 #
 # Documentation
-#   - https://github.com/nixwiz/sensu-aws-sns-handler#sensu-aws-sns-handler
+#   - https://github.com/sensu/sensu-aws-sns-handler#sensu-aws-sns-handler
 #   - https://docs.sensu.io/sensu-go/latest/reference/secrets/
 #
 # Contributors
@@ -59,7 +59,7 @@ spec:
     - not_silenced
   handlers: null
   runtime_assets:
-    - nixwiz/sensu-aws-sns-handler:0.2.0
+    - sensu/sensu-aws-sns-handler:0.3.0
   secrets:
     - name: AWS_SECRET_ACCESS_KEY
       secret: aws_secret_access_key
@@ -107,45 +107,44 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu-aws-sns-handler:0.2.0
+  name: sensu-aws-sns-handler:0.3.0
   labels:
   annotations:
-    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/nixwiz/sensu-aws-sns-handler
-    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/nixwiz/sensu-aws-sns-handler
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-aws-sns-handler
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-aws-sns-handler
     io.sensu.bonsai.tier: Community
-    io.sensu.bonsai.version: 0.2.0
-    io.sensu.bonsai.namespace: nixwiz
+    io.sensu.bonsai.version: 0.3.0
+    io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.name: sensu-aws-sns-handler
     io.sensu.bonsai.tags: aws, handler
 spec:
-  builds:
-    - url: https://assets.bonsai.sensu.io/5c303a960fa9024705f74d16851caa4ffcd72d42/sensu-aws-sns-handler_0.2.0_darwin_amd64.tar.gz
-      sha512: f1a756e027f57fc9aaedd5bfa10e942bc4f89f935f2418e72c0376de40dc6b2ceb0cc34f79a5b4f1154b9558a336b6460f9ab56068bfe2ce8711fedaa356222e
-      filters:
-        - entity.system.os == 'darwin'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/5c303a960fa9024705f74d16851caa4ffcd72d42/sensu-aws-sns-handler_0.2.0_linux_armv7.tar.gz
-      sha512: '059348fb1793c0a47cabc6654a8755a45352f5ffdd988d61b0c2e6abda92531c8a551adf8220955316b8e2ac7c3d0fedeb369ec8873b010a97bb85ec08c7507b'
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'armv7'
-    - url: https://assets.bonsai.sensu.io/5c303a960fa9024705f74d16851caa4ffcd72d42/sensu-aws-sns-handler_0.2.0_linux_arm64.tar.gz
-      sha512: 9f23e2f259bd39d5fe2a70abe57847dc7435a18a833c9146dffe2568d5ec762a8b93a98e1d72a77d3d05faef11ff43c3860285f016a48b4028f0565ba674a36f
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'arm64'
-    - url: https://assets.bonsai.sensu.io/5c303a960fa9024705f74d16851caa4ffcd72d42/sensu-aws-sns-handler_0.2.0_linux_386.tar.gz
-      sha512: 4369889e333362493ecbbf4da2bafcc0b1543b0a0fed620adacb28935898b45a1c541dcc5c5a38342a740f2044a0fa86dc869a0e6d60a92e7a657c0e6878e6f2
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == '386'
-    - url: https://assets.bonsai.sensu.io/5c303a960fa9024705f74d16851caa4ffcd72d42/sensu-aws-sns-handler_0.2.0_linux_amd64.tar.gz
-      sha512: dee9f75fe76d5db553fb178eb5cdbe79b755b086ff8e271c6dbcdb1614e2f4e124970e8d54768ac79bdce67c08818436e429de32e4a49ee149003d6604b555ac
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/5c303a960fa9024705f74d16851caa4ffcd72d42/sensu-aws-sns-handler_0.2.0_windows_amd64.tar.gz
-      sha512: dd27d56cfb1d36bbc8e640b5815cb2772c2177bd40e202324a97dbb118d748b992c7261391c1c1c89a8ca4ec0a942f66982c4feb79bf2bb62199c9d3c94dfc7b
-      filters:
-        - entity.system.os == 'windows'
-        - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/fb3a5096b2a15d190d9b23fe1596328b3a27fc3e/sensu-aws-sns-handler_0.3.0_windows_amd64.tar.gz
+    sha512: 336fc3e78851967661394d6714e592f195ac696f630edf41fdcd996466957411d38788c5173dc41a3ca3a663747dcc947359d09a9abe54f137866bb9abd07201
+    filters:
+      - entity.system.os == 'windows'
+      - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/fb3a5096b2a15d190d9b23fe1596328b3a27fc3e/sensu-aws-sns-handler_0.3.0_darwin_amd64.tar.gz
+    sha512: be9a57d5f705a8326c07b99a5ae274d92324e2ad28427dcff9e48c16fdcf39c2cf6fa18fcd62c8352a0eae4ec629a368f309abebe3fde81064d4e3b706a96b1b
+    filters:
+      - entity.system.os == 'darwin'
+      - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/fb3a5096b2a15d190d9b23fe1596328b3a27fc3e/sensu-aws-sns-handler_0.3.0_linux_armv7.tar.gz
+    sha512: 6dc9b21cfad70bd458570ac4fd245b2d4a83ce6eda9f777aba04575a8ad90dc45631d5ce35a74192a719b93440695b92c453937df4de07cb45772fe827a5ab6e
+    filters:
+      - entity.system.os == 'linux'
+      - entity.system.arch == 'armv7'
+  - url: https://assets.bonsai.sensu.io/fb3a5096b2a15d190d9b23fe1596328b3a27fc3e/sensu-aws-sns-handler_0.3.0_linux_arm64.tar.gz
+    sha512: a76195d0fcf29a3b4d518bca29eb2f5cd84e6612437a791acfde3e240a0a6dfe68d1b74cdb06cba0069c9f1d68b9cded67440579752c4438ccc71880c63a7de1
+    filters:
+      - entity.system.os == 'linux'
+      - entity.system.arch == 'arm64'
+  - url: https://assets.bonsai.sensu.io/fb3a5096b2a15d190d9b23fe1596328b3a27fc3e/sensu-aws-sns-handler_0.3.0_linux_386.tar.gz
+    sha512: c312de3a4f5f22d224a5d943b3eb9f5bd567d4e38db9db82f72bd99f9835ba3c8f66f95c07ba46dea6aa7169b1f8b35d7da00eac742097fb676547cbfdb5606d
+    filters:
+      - entity.system.os == 'linux'
+      - entity.system.arch == '386'
+  - url: https://assets.bonsai.sensu.io/fb3a5096b2a15d190d9b23fe1596328b3a27fc3e/sensu-aws-sns-handler_0.3.0_linux_amd64.tar.gz
+    sha512: 0007f7dbe1a9cc5c040a07a0c1e74a74a23b233c0b5eab0b86f60cedb35272486eabb9e27e9cb28c965af0825991b0284c23af7bdcd9c8244f90c2ac622523b7
+    filters:
+      - entity.system.os == 'linux'
+      - entity.system.arch == 'amd64'


### PR DESCRIPTION
My SNS handler has been moved to the Sensu org and a new release created.  Update to reference the new org and assets.

Signed-off-by: Todd Campbell <todd@sensu.io>