### PR TITLE
Fix sumologic asset references

### DIFF
--- a/pipelines/event-storage/sumologic.yaml
+++ b/pipelines/event-storage/sumologic.yaml
@@ -68,7 +68,7 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu-sumologic-handler:0.1.0
+  name: sensu/sensu-sumologic-handler:0.1.0
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-sumologic-handler
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-sumologic-handler

--- a/pipelines/metric-storage/sumologic.yaml
+++ b/pipelines/metric-storage/sumologic.yaml
@@ -69,7 +69,7 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu-sumologic-handler:0.1.0
+  name: sensu/sensu-sumologic-handler:0.1.0
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-sumologic-handler
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-sumologic-handler


### PR DESCRIPTION
Handlers were referencing `sensu/sensu-sumologic-handler:0.1.0` and assets were named `sensu-sumologic-handler:0.1.0` (no `sensu/` prefix). 