### PR TITLE
Add initial generate/publish API workflow

### DIFF
--- a/.github/actions/generate-catalog-api/Dockerfile
+++ b/.github/actions/generate-catalog-api/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.15
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN apk add curl
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/generate-catalog-api/action.yml
+++ b/.github/actions/generate-catalog-api/action.yml
@@ -1,0 +1,20 @@
+---
+name: 'Sensu Catalog API Generator'
+description: 'Generate Sensu Catalog API from a Catalog repository'
+author: 'sensu'
+inputs:
+  catalog-api-version:
+    description: 'The version of the API tool to use'
+    required: true
+    default: '0.1.0-alpha.4'
+outputs:
+  release-dir:
+    description: 'The path of the generated release directory'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.catalog-api-version }}
+branding:
+  icon: 'globe'
+  color: 'green'

--- a/.github/actions/generate-catalog-api/entrypoint.sh
+++ b/.github/actions/generate-catalog-api/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -l
+
+echo "Downloading & installing catalog-api"
+catalog_api_version="$1"
+catalog_api_os="linux"
+catalog_api_arch="amd64"
+catalog_api_filename="catalog-api_${catalog_api_version}_${catalog_api_os}_${catalog_api_arch}.tar.gz"
+catalog_api_url="https://github.com/sensu/catalog-api/releases/download/${catalog_api_version}/${catalog_api_filename}"
+echo "URL: ${catalog_api_url}"
+curl -L "$catalog_api_url" | gunzip -c | tar -x -C /usr/bin
+
+
+echo "Creating tmp directory for generated files"
+mkdir -p ./tmp
+
+echo "Generating Catalog API"
+catalog-api generate --temp-dir "./tmp"

--- a/.github/actions/publish-catalog-api/Dockerfile
+++ b/.github/actions/publish-catalog-api/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.15
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN apk add aws-cli
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/publish-catalog-api/action.yml
+++ b/.github/actions/publish-catalog-api/action.yml
@@ -1,0 +1,16 @@
+---
+name: 'Sensu Catalog API Publisher'
+description: 'Publish a generated Sensu Catalog API'
+author: 'sensu'
+inputs:
+  release-dir:
+    description: 'The path to the generated release directory'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.release-dir }}
+branding:
+  icon: 'globe'
+  color: 'green'

--- a/.github/actions/publish-catalog-api/entrypoint.sh
+++ b/.github/actions/publish-catalog-api/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+
+echo "Publishing Catalog API"
+
+aws s3 cp "$1" "s3://${AWS_S3_BUCKET}" \
+    --recursive \
+    --exclude version.json \
+    --cache-control 'max-age=31104000' # 360 days
+
+aws s3 cp "${1}/version.json" "s3://${AWS_S3_BUCKET}" \
+    --cache-control 'no-cache' \
+    --acl 'public-read'

--- a/.github/workflows/catalog-api-generator.yml
+++ b/.github/workflows/catalog-api-generator.yml
@@ -1,0 +1,28 @@
+---
+name: 'Generate Sensu Catalog API'
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  generate-and-publish-api:
+    name: 'Generate & Publish Catalog API'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0  # The whole repository must be cloned
+      - uses: ./.github/actions/generate-catalog-api
+        id: generate-api
+        with:
+          catalog-api-version: 0.1.0-alpha.4
+      - uses: ./.github/actions/publish-catalog-api
+        with:
+          release-dir: ${{ steps.generate-api.outputs.release-dir }}
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
Closes #54.
Closes #55.

This implements the generation & publishing of a static catalog API whenever a tag is pushed. I am planning on adding support for validating PRs separately.