### PR TITLE
Trigger GitHub Actions on tagged PRs

### DIFF
--- a/.github/workflows/catalog-api-generator.yml
+++ b/.github/workflows/catalog-api-generator.yml
@@ -2,6 +2,9 @@
 name: 'Generate Sensu Catalog API'
 
 on:
+  pull_request:
+    tags:
+      - '*'
   push:
     tags:
       - '*'


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

I believe the previous tag didn't trigger a CI run due to the tag being created from the PR. This should enable CI for tags created from PRs.