### PR TITLE
Fix typo in integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ spec:
         filter: .metadata.labels.provider == "alerts"
         required: false
     - type: question
-      name: alert_pipeline
+      name: incident_pipeline
       input:
         type: string
         title: Incident Management Pipeline


### PR DESCRIPTION
The example had two prompt attributes named `alert_pipeline`. 