### PR TITLE
Catalog maintenance

### DIFF
--- a/.github/workflows/catalog-api-generator.yml
+++ b/.github/workflows/catalog-api-generator.yml
@@ -2,9 +2,6 @@
 name: 'Generate Sensu Catalog API'
 
 on:
-  pull_request:
-    tags:
-      - '*'
   push:
     tags:
       - '**'

--- a/.github/workflows/catalog-api-generator.yml
+++ b/.github/workflows/catalog-api-generator.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ./.github/actions/generate-catalog-api
         id: generate-api
         with:
-          catalog-api-version: 0.1.0-alpha.6
+          catalog-api-version: 0.1.0-alpha.7
       - uses: ./.github/actions/publish-catalog-api
         with:
           release-dir: ${{ steps.generate-api.outputs.release-dir }}

--- a/README.md
+++ b/README.md
@@ -216,22 +216,14 @@ spec:
 
   Integration provider. Must be one of the following values:
 
-  * `application`
-  * `agent`
-  * `agent/monitoring`
-  * `agent/discovery`
-  * `backend`
-  * `backend/alert`
-  * `backend/incidents`
-  * `backend/metrics`
-  * `backend/events`
-  * `backend/deregistration`
-  * `backend/remediation`
-  * `backend/other`
-  * `cli`
-  * `cli/command`
-  * `universal`
-  * `universal/runtime`
+  * `monitoring`
+  * `discovery`
+  * `alerts`
+  * `incidents`
+  * `metrics`
+  * `events`
+  * `deregistration`
+  * `remediation`
 
 * `short_description`
 

--- a/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ansible-tower-remediation
 spec:
   class: community # community, supported, enterprise, or partner
-  provider: backend/remediation # backend, backend/alert, backend/incidents, backend/metrics, backend/events, backend/deregistration, backend/remediation, or backend/other
+  provider: remediation # backend, backend/alert, backend/incidents, backend/metrics, backend/events, backend/deregistration, backend/remediation, or backend/other
   short_description: Ansible Tower Remediation
   tags:
   - ansible

--- a/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: ansible
   name: ansible-tower-remediation
 spec:
-  class: community # community, supported, enterprise, or partner
-  provider: remediation # backend, backend/alert, backend/incidents, backend/metrics, backend/events, backend/deregistration, backend/remediation, or backend/other
+  class: community
+  provider: remediation
   short_description: Ansible Tower Remediation
   tags:
   - ansible

--- a/integrations/cassandra/cassandra-monitoring/sensu-integration.yaml
+++ b/integrations/cassandra/cassandra-monitoring/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cassandra-monitoring
 spec:
   class: community
-  provider: agent/monitoring
+  provider: monitoring
   short_description: Cassandra Monitoring
   supported_platforms:
     - darwin

--- a/integrations/example/helloworld/sensu-integration.yaml
+++ b/integrations/example/helloworld/sensu-integration.yaml
@@ -3,45 +3,49 @@ api_version: catalog/v1
 type: Integration
 metadata:
   namespace: example
-  name: helloworld
-spec:
+  path: /helloworld/spec:
   class: community
   provider: monitoring
   short_description: Example Sensu Integration
   supported_platforms:
-  - linux
-  - windows
-  - darwin
+    - linux
+    - windows
+    - darwin
   tags:
-  - example
-  - helloworld
+    - example
+    - helloworld
   contributors:
-  - "@sensu"
+    - "@sensu"
   prompts:
-  - var: integration_name
-    type: string
-    prompt: "Integration Name"
-    default: helloworld
-  - var: integration_interval
-    type: int
-    prompt: "How often do you want to perform this healthcheck (in seconds)?"
-    default: 30
-  - var: integration_world
-    type: int
-    prompt: "What world do you want to greet?"
-    default: 30
-  resource_updates:
-  - type: CheckConfig
-    api_version: core/v2
-    name: helloworld
-    fields:
-    - name: metadata.name
-      action: replace
-      value: integration_name
-    - name: spec.interval
-      action: replace
-      value: integration_interval
-    - name: spec.command
-      action: replace
-      template: >-
-        echo "Hello {{ .annotations.helloworld | default '[[ integration_world ]]' }} world!"
+    - type: question
+      name: integration_name
+      input:
+        type: string
+        title: "Integration Name"
+        default: helloworld
+    - name: integration_interval
+      type: int
+      input:
+        title: "How often do you want to perform this healthcheck (in seconds)?"
+        default: 30
+    - name: integration_world
+      type: int
+      input:
+        title: "What world do you want to greet?"
+        default: 30
+  resource_patches:
+    - resource:
+        type: CheckConfig
+        api_version: core/v2
+        name: helloworld
+      patches:
+        - path: /metadata/name
+          op: replace
+          value: "[[integration_name]]"
+        - path: /spec/interval
+          op: replace
+          value: "[[integration_interval]]"
+        - path: /spec/command
+          op: replace
+          template: >-
+            echo "Hello {{ .annotations.helloworld | default '[[ integration_world ]]' }} world!"

--- a/integrations/example/helloworld/sensu-integration.yaml
+++ b/integrations/example/helloworld/sensu-integration.yaml
@@ -1,12 +1,12 @@
 ---
-api_version: v1
+api_version: catalog/v1
 type: Integration
 metadata:
   namespace: example
   name: helloworld
 spec:
   class: community
-  provider: agent/check
+  provider: monitoring
   short_description: Example Sensu Integration
   supported_platforms:
   - linux

--- a/integrations/mattermost/mattermost-alerts/sensu-integration.yaml
+++ b/integrations/mattermost/mattermost-alerts/sensu-integration.yaml
@@ -1,15 +1,15 @@
 ---
 type: Integration
-api_version: v1
+api_version: catalog/v1
 metadata:
   namespace: mattermost
   name: mattermost-alerts
 spec:
   class: supported
-  provider: backend/alerts
+  provider: alerts
   short_description: Mattermost Alerts
   tags:
-  - mattermost  
+  - mattermost
   - alerts
   contributors:
   - "@sensu"

--- a/integrations/nginx/nginx-monitoring/sensu-integration.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: nginx-monitoring
 spec:
   class: community
-  provider: agent/check
+  provider: monitoring
   short_description: NGINX monitoring
   supported_platforms:
   - darwin

--- a/integrations/pagerduty/pagerduty-incidents/sensu-integration.yaml
+++ b/integrations/pagerduty/pagerduty-incidents/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pagerduty-incidents
 spec:
   class: supported
-  provider: backend/incidents
+  provider: incidents
   short_description: Pagerduty Incidents
   tags:
   - pagerduty

--- a/integrations/slack/slack-alerts/sensu-integration.yaml
+++ b/integrations/slack/slack-alerts/sensu-integration.yaml
@@ -1,12 +1,12 @@
 ---
 type: Integration
-api_version: v1
+api_version: catalog/v1
 metadata:
   namespace: slack
   name: slack-alerts
 spec:
   class: supported
-  provider: backend/alerts
+  provider: alerts
   short_description: Slack Alerts
   tags:
   - slack

--- a/integrations/system/host-monitoring/sensu-integration.yaml
+++ b/integrations/system/host-monitoring/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: host-monitoring
 spec:
   class: supported
-  provider: agent/check
+  provider: monitoring
   short_description: Host monitoring
   supported_platforms:
   - darwin

--- a/templates/check-template/sensu-integration.yaml
+++ b/templates/check-template/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{integration_name}}
 spec:
   class: community # community, supported, enterprise, or partner
-  provider: agent/monitoring # should be one of: "agent", "agent/monitoring", or "agent/discovery"
+  provider: monitoring
   short_description: {{integration_short_name}}
   supported_platforms:
     - darwin

--- a/templates/pipeline-template/sensu-integration.yaml
+++ b/templates/pipeline-template/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{integration_name}}
 spec:
   class: community # community, supported, enterprise, or partner
-  provider: incidents # should be one of: "alerts", "incidents", "metrics", "events", "deregistration", "remediation"
+  provider: incidents # should be one of: "alerts", "incidents", "metrics", "events", "deregistration", "remediation", "discovery"
   short_description: {{integration_short_name}}
   supported_platforms:
     - darwin

--- a/templates/pipeline-template/sensu-integration.yaml
+++ b/templates/pipeline-template/sensu-integration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{integration_name}}
 spec:
   class: community # community, supported, enterprise, or partner
-  provider: backend/incidents # should be one of: "backend", "backend/alert", "backend/incidents", "backend/metrics", "backend/events", "backend/deregistration", "backend/remediation", or "backend/other"
+  provider: incidents # should be one of: "alerts", "incidents", "metrics", "events", "deregistration", "remediation"
   short_description: {{integration_short_name}}
   supported_platforms:
     - darwin


### PR DESCRIPTION
- Updated list of providers 
- Update integration `api_version` to be `catalog/v1`
- Update prototype prompts to new spec (see helloworld example)
- Update GitHub action catalog-api version 