### PR TITLE
Fix cache path

### DIFF
--- a/.github/actions/generate-catalog-api/action.yml
+++ b/.github/actions/generate-catalog-api/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'The version of the API tool to use'
     required: true
     default: '0.1.0-alpha.10'
+  temp-dir:
+    description: 'The path to a temp directory to store the generated API files'
+    required: true
+    default: 'tmp'
 outputs:
   release-dir:
     description: 'The path of the generated release directory'

--- a/.github/actions/generate-catalog-api/action.yml
+++ b/.github/actions/generate-catalog-api/action.yml
@@ -19,6 +19,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.catalog-api-version }}
+    - ${{ inputs.temp-dir }}
 branding:
   icon: 'globe'
   color: 'green'

--- a/.github/actions/generate-catalog-api/entrypoint.sh
+++ b/.github/actions/generate-catalog-api/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh -l
 
-echo "Downloading & installing catalog-api"
 catalog_api_version="$1"
+temp_dir="$2"
+
+echo "Downloading & installing catalog-api"
 catalog_api_os="linux"
 catalog_api_arch="amd64"
 catalog_api_filename="catalog-api_${catalog_api_version}_${catalog_api_os}_${catalog_api_arch}.tar.gz"
@@ -14,5 +16,5 @@ echo "Creating tmp directory for generated files"
 mkdir -p ./tmp
 
 echo "Generating Catalog API"
-catalog-api catalog generate --temp-dir "./tmp"
+catalog-api catalog generate --temp-dir "$temp_dir"
 chown -R 1001:1001 tmp

--- a/.github/actions/generate-catalog-api/entrypoint.sh
+++ b/.github/actions/generate-catalog-api/entrypoint.sh
@@ -15,3 +15,4 @@ mkdir -p ./tmp
 
 echo "Generating Catalog API"
 catalog-api catalog generate --temp-dir "./tmp"
+chown -R 1001:1001 tmp

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 env:
   cache_key: ${{ github.workflow }}-${{ github.run_number }}-${{ github.run_attempt }}
   catalog_api_version: 0.1.0-alpha.10
-  catalog_temp_dir: tmp
+  catalog_temp_dir: ./tmp
 
 jobs:
   validate:

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run Sensu Catalog API publisher
         uses: ./.github/actions/publish-catalog-api
         with:
-          release-dir: ${{ steps.generate-api.outputs.release-dir }}
+          release-dir: ${{ needs.generate.outputs.release-dir }}
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 env:
   cache_key: ${{ github.workflow }}-${{ github.run_number }}-${{ github.run_attempt }}
   catalog_api_version: 0.1.0-alpha.10
+  catalog_temp_dir: tmp
 
 jobs:
   validate:
@@ -32,14 +33,14 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v2
         with:
-          path: tmp
+          path: ${{ env.catalog_temp_dir }}
           key: ${{ env.cache_key }}
       - name: Run Sensu Catalog API generation
         uses: ./.github/actions/generate-catalog-api
         id: generate-api
         with:
           catalog-api-version: ${{ env.catalog_api_version }}
-      - run: ls -l tmp
+          temp-dir: ${{ env.catalog_temp_dir }}
 
   publish:
     name: 'Publish Sensu Catalog API'
@@ -52,9 +53,8 @@ jobs:
       - name: Restore Cache
         uses: actions/cache@v2
         with:
-          path: tmp
+          path: ${{ env.catalog_temp_dir }}
           key: ${{ env.cache_key }}
-      - run: ls -l tmp
       - name: Run Sensu Catalog API publisher
         uses: ./.github/actions/publish-catalog-api
         with:

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -38,6 +38,7 @@ jobs:
         id: generate-api
         with:
           catalog-api-version: ${{ env.catalog_api_version }}
+      - run: ls -l tmp
 
   publish:
     name: 'Publish Sensu Catalog API'
@@ -52,6 +53,7 @@ jobs:
         with:
           path: tmp
           key: generated-catalog-api
+      - run: ls -l tmp
       - name: Run Sensu Catalog API publisher
         uses: ./.github/actions/publish-catalog-api
         with:

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(fromJson('["push", "create"]'), github.event_name) && contains(github.ref, 'refs/tags/')
     needs: validate
+    outputs:
+      release-dir: ${{ steps.generate-api.outputs.release-dir }}
     steps:
       - uses: actions/checkout@master
         with:
@@ -29,7 +31,7 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.generate-api.outputs.release-dir }}
+          path: tmp
           key: generated-catalog-api
       - name: Run Sensu Catalog API generation
         uses: ./.github/actions/generate-catalog-api
@@ -45,7 +47,7 @@ jobs:
       - name: Restore Cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.generate-api.outputs.release-dir }}
+          path: tmp
           key: generated-catalog-api
       - name: Run Sensu Catalog API publisher
         uses: ./.github/actions/publish-catalog-api

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -44,6 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0  # The whole repository must be cloned
       - name: Restore Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -2,6 +2,7 @@
 name: 'Sensu Catalog Workflow'
 on: [push, pull_request]
 env:
+  cache_key: ${{ github.workflow }}-${{ github.run_number }}-${{ github.run_attempt }}
   catalog_api_version: 0.1.0-alpha.10
 
 jobs:
@@ -32,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: tmp
-          key: generated-catalog-api
+          key: ${{ env.cache_key }}
       - name: Run Sensu Catalog API generation
         uses: ./.github/actions/generate-catalog-api
         id: generate-api
@@ -52,7 +53,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: tmp
-          key: generated-catalog-api
+          key: ${{ env.cache_key }}
       - run: ls -l tmp
       - name: Run Sensu Catalog API publisher
         uses: ./.github/actions/publish-catalog-api


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The release-dir output isn't available when the cache path is needed. Add an input which allows the temp-dir flag to be set from a workflow and use it as the path to cache.