### PR TITLE
Updated Ansible Tower prompts

### DIFF
--- a/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
@@ -23,34 +23,22 @@ spec:
       title: Ansible Tower API Configuration
     - type: markdown
       body: |
-        This integration requires a Ansible Tower API URL and API Token for API Authentication.
+        This integration requires a Ansible Tower API Host and API Token for API Authentication.
 
         Please visit [Ansible Tower API OAuth Guide] for more information.
 
         [Ansible Tower OAuth Guide]: https://docs.ansible.com/ansible-tower/latest/html/administration/oauth2_token_auth.html
     - type: section
-      title: Ansible Tower API URL
+      title: Ansible Tower API Configuration
     - type: question
-      name: api_url_secret_provider
+      name: api_host
+      required: true
       input:
         type: string
-        title: Ansible Tower API URL Secret Provider
+        title: Ansible Tower API Host
         description: >-
-          Select the API URL secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: api_url_secret_id
-      input:
-        type: string
-        title: Ansible Tower API URL Secret ID
-        description: >-
-          Provide the API URL secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_ANSIBLE_TOWER_HOST
-    - type: section
-      title: Ansible Tower API Token
+          Provide the API Host (i.e. hostname or IP address)
+        default: "127.0.0.1"
     - type: question
       name: api_token_secret_provider
       input:
@@ -72,16 +60,13 @@ spec:
         default: SENSU_ANSIBLE_TOWER_TOKEN
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: ansible_tower_host
+        api_version: core/v2
+        type: Handler
+        name: ansible-tower
       patches:
-        - path: /spec/provider
+        - path: /spec/env_vars/0
           op: replace
-          value: "[[api_url_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[api_url_secret_id]]"
+          value: ANSIBLE_HOST=127.0.0.1
     - resource:
         api_version: secrets/v1
         type: Secret

--- a/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
@@ -27,7 +27,7 @@ spec:
 
         Please visit [Ansible Tower API OAuth Guide] for more information.
 
-        [Ansible Tower OAuth Guide]: https://docs.ansible.com/ansible-tower/latest/html/administration/oauth2_token_auth.html
+        [Ansible Tower API OAuth Guide]: https://docs.ansible.com/ansible-tower/latest/html/administration/oauth2_token_auth.html
     - type: section
       title: Ansible Tower API Configuration
     - type: question

--- a/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
@@ -20,7 +20,7 @@ spec:
     - "@jspaleta"
   prompts:
     - type: section
-      title: Mattermost Secrets
+      title: Ansible Tower API Configuration
     - type: markdown
       body: |
         This integration requires a Ansible Tower API URL and API Token for API Authentication.

--- a/integrations/ansible/ansible-tower-remediation/sensu-resources.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-resources.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   workflows:
     - name: ansible-tower
-      filters: []
-      mutator: {}
       handler:
         api_version: core/v2
         type: Handler
@@ -16,8 +14,6 @@ spec:
 type: Handler
 api_version: core/v2
 metadata:
-  labels:
-    sensu.io/managed_by: sensuctl
   name: ansible-tower
 spec:
   type: pipe

--- a/integrations/ansible/ansible-tower-remediation/sensu-resources.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-resources.yaml
@@ -25,19 +25,11 @@ spec:
   runtime_assets:
     - sensu/sensu-ansible-handler:2.1.0
   timeout: 10
+  env_vars:
+    - ANSIBLE_HOST=127.0.0.1
   secrets:
-    - name: ANSIBLE_HOST
-      secret: ansible_tower_host
     - name: ANSIBLE_TOKEN
       secret: ansible_tower_token
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: ansible_tower_host
-spec:
-  provider: env
-  id: SENSU_ANSIBLE_TOWER_HOST
 ---
 type: Secret
 api_version: secrets/v1


### PR DESCRIPTION
- [x] fix a copy pasta typo, s/mattermost/ansible tower/
- [x] fix a configuration parameter typo, s/url/host/ 
- [x] use an env_var instead of secret for host configuration
- [x] simplify prompts