### PR TITLE
Update NGINX integration to use new official plugin

### DIFF
--- a/integrations/nginx/nginx-monitoring/CHANGELOG.md
+++ b/integrations/nginx/nginx-monitoring/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][changelog] and this project adheres
+to [Semantic Versioning][semver].
+
+## Unreleased
+
+- Initial implementation of `nginx/nginx-monitoring` integration.
+
+[changelog]: http://keepachangelog.com/en/1.0.0/
+[semver]: http://semver.org/spec/v2.0.0.html

--- a/integrations/nginx/nginx-monitoring/README.md
+++ b/integrations/nginx/nginx-monitoring/README.md
@@ -2,16 +2,14 @@
 
 <!-- Sensu Integration description; supports markdown -->
 
-Monitor NGINX health status using the [NGINX `stub_status` module][nginx_stub_status].
+Collect metrics and monitor NGINX health status using the [NGINX `stub_status` module][nginx_stub_status].
 
 <!-- Provide a high level overview of the integration contents (e.g. checks, filters, mutators, handlers, assets, etc) -->
 
 This integration provides the following resources:
 
-* `nginx-healthcheck` [check]
 * `nginx-metrics` [check]
-* `sensu-plugins/sensu-plugins-nginx:3.1.2` [asset]
-* `sensu/sensu-ruby-runtime:0.0.10` [asset]
+* `sensu/nginx-check:0.1.0` [asset]
 
 ### Dashboards
 
@@ -48,8 +46,7 @@ This integration is compatible with the [Sumo Logic NGINX app][sumologic-nginx-a
 
 <!-- Links to any Sensu Integration dependencies (i.e. Sensu Plugins) -->
 
-- [sensu-plugins/sensu-plugins-nginx:3.1.2][sensu-plugins-nginx-bonsai] ([GitHub][sensu-plugins-nginx-github])
-- [sensu/sensu-ruby-runtime:0.0.10][sensu-ruby-runtime-github] ([GitHub][sensu-ruby-runtime-github])
+- [sensu/nginx-check:0.1.0][sensu-nginx-check-bonsai] ([GitHub][sensu-nginx-check-github])
 
 ## Metrics & Events
 
@@ -57,32 +54,32 @@ This integration is compatible with the [Sumo Logic NGINX app][sumologic-nginx-a
 
 This integration collects the following [metrics]:
 
-* `active_connections`
+* `nginx_active`
 
   The current number of active client connections including `Waiting` connections.
 
-* `accepts`
+* `nginx_accepts`
 
   The total number of accepted client connections.
 
-* `handled`
+* `nginx_handled`
 
   The total number of handled connections.
   Generally, the parameter value is the same as accepts unless some resource limits have been reached (for example, the [`worker_connections` limit][worker_connections_limit]).
 
-* `requests`
+* `nginx_requests`
 
   The total number of client requests.
 
-* `reading`
+* `nginx_reading`
 
   The current number of connections where nginx is reading the request header.
 
-* `writing`
+* `nginx_writing`
 
   The current number of connections where nginx is writing the response back to the client.
 
-* `waiting`
+* `nginx_waiting`
 
   The current number of idle client connections waiting for a request.
 
@@ -92,7 +89,11 @@ This integration collects the following [metrics]:
 
 This integration produces the following events that should be processed by an alert or incident management [handler]:
 
-* N/A
+* Produces `WARN` if values for `nginx_active` or `nginx_waiting` are exceed threshold.
+* Default thresholds are:
+    * `nginx_active`: 300
+    * `nginx_waiting`: 30
+* Produces `CRITICAL` if `nginx_status` endpoint is unreachable.
 
 ## Reference Documentation
 
@@ -114,8 +115,6 @@ This integration produces the following events that should be processed by an al
 [sumologic-nginx-app]: https://www.sumologic.com/application/nginx/
 [sensu-plus]: https://sensu.io/features/analytics
 [nginx_stub_status]: https://nginx.org/en/docs/http/ngx_http_stub_status_module.html
-[sensu-plugins-nginx-bonsai]: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-nginx
-[sensu-plugins-nginx-github]: https://github.com/sensu-plugins/sensu-plugins-nginx
-[sensu-ruby-runtime-bonsai]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
-[sensu-ruby-runtime-github]: https://github.com/sensu/sensu-ruby-runtime
+[sensu-nginx-check-bonsai]: https://bonsai.sensu.io/assets/sensu/nginx-check
+[sensu-nginx-check-github]: https://github.com/sensu/nginx-check
 [worker_connections_limit]: https://nginx.org/en/docs/ngx_core_module.html#worker_connections

--- a/integrations/nginx/nginx-monitoring/sensu-integration.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-integration.yaml
@@ -21,6 +21,33 @@ spec:
     - "@nixwiz"
     - "@calebhailey"
   prompts:
+    - type: section
+      title: Configure NGINX Monitoring Thresholds
+    - type: markdown
+      body: |
+        This integration collects metrics from NGINX.
+        Configure the default alerting thresholds for active and waiting connections.
+    - type: question
+      name: nginx_active_warn
+      required: false
+      input:
+        type: integer
+        title: Active Connections Warning Threshold
+        description: Default "nginx_active" warning threshold.
+        default: 300
+    - type: question
+      name: nginx_waiting_warn
+      required: false
+      input:
+        type: integer
+        title: Waiting Connection Warning Threshold
+        description: Default "nginx_waiting" warning threshold.
+        default: 30
+    - type: section
+      title: Configure Event Processing Pipelines
+    - type: markdown
+      body: |
+        Configure the event processing pipelines for processing events and metrics about NGINX.
     - type: question
       name: metrics_pipeline
       required: false
@@ -63,7 +90,7 @@ spec:
     - resource:
         api_version: core/v2
         type: CheckConfig
-        name: nginx-healthcheck
+        name: nginx-metrics
       patches:
         - path: /spec/pipelines/-
           op: add
@@ -77,3 +104,9 @@ spec:
             api_version: core/v2
             type: Pipeline
             name: "[[incidents_pipeline]]"
+        - path: /spec/output_metric_thresholds/0/thresholds/0/max
+          op: replace
+          value: "[[nginx_active_warn]]"
+        - path: /spec/output_metric_thresholds/1/thresholds/0/max
+          op: replace
+          value: "[[nginx_waiting_warn]]"  

--- a/integrations/nginx/nginx-monitoring/sensu-integration.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-integration.yaml
@@ -47,7 +47,7 @@ spec:
       title: Configure Event Processing Pipelines
     - type: markdown
       body: |
-        Configure the event processing pipelines for processing events and metrics about NGINX.
+        Configure the event processing pipelines for processing NGINX events and metrics.
     - type: question
       name: metrics_pipeline
       required: false

--- a/integrations/nginx/nginx-monitoring/sensu-integration.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-integration.yaml
@@ -41,7 +41,7 @@ spec:
       input:
         type: integer
         title: Waiting Connection Warning Threshold
-        description: Default "nginx_waiting" warning threshold.
+        description: The "nginx_waiting" warning threshold.
         default: 30
     - type: section
       title: Configure Event Processing Pipelines

--- a/integrations/nginx/nginx-monitoring/sensu-integration.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-integration.yaml
@@ -33,7 +33,7 @@ spec:
       input:
         type: integer
         title: Active Connections Warning Threshold
-        description: Default "nginx_active" warning threshold.
+        description: The "nginx_active" warning threshold.
         default: 300
     - type: question
       name: nginx_waiting_warn

--- a/integrations/nginx/nginx-monitoring/sensu-integration.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-integration.yaml
@@ -26,7 +26,7 @@ spec:
     - type: markdown
       body: |
         This integration collects metrics from NGINX.
-        Configure the default alerting thresholds for active and waiting connections.
+        Configure the alerting thresholds for active and waiting connections.
     - type: question
       name: nginx_active_warn
       required: false

--- a/integrations/nginx/nginx-monitoring/sensu-resources.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-resources.yaml
@@ -32,7 +32,7 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: nginx-check:0.1.0
+  name: sensu/nginx-check:0.1.0
   labels: 
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/nginx-check

--- a/integrations/nginx/nginx-monitoring/sensu-resources.yaml
+++ b/integrations/nginx/nginx-monitoring/sensu-resources.yaml
@@ -2,135 +2,83 @@
 type: CheckConfig
 api_version: core/v2
 metadata:
-  name: nginx-healthcheck
-spec:
-  command: >-
-    check-nginx-status.rb
-    --url {{ .annotations.check_nginx_status_url | default "http://localhost:80/nginx_status" }}
-  runtime_assets:
-    - sensu-plugins/sensu-plugins-nginx:3.1.2
-    - sensu/sensu-ruby-runtime:0.0.10
-  publish: true
-  subscriptions:
-    - nginx
-  interval: 30
-  timeout: 10
-  pipelines: []
----
-type: CheckConfig
-api_version: core/v2
-metadata:
   name: nginx-metrics
 spec:
   command: >-
-    metrics-nginx.rb
+    nginx-check
     --url {{ .annotations.metrics_nginx_url | default "http://localhost:80/nginx_status" }}
   runtime_assets:
-    - sensu-plugins/sensu-plugins-nginx:3.1.2
-    - sensu/sensu-ruby-runtime:0.0.10
+    - sensu/nginx-check:0.1.0
   publish: false
   subscriptions:
     - nginx
   interval: 30
   timeout: 10
-  output_metric_format: graphite_plaintext
+  output_metric_format: prometheus_text
   output_metric_tags:
     - name: entity
       value: "{{ .name }}"
+  output_metric_thresholds:
+    - name: nginx_active
+      thresholds:
+        - max: "300"
+          status: 1
+    - name: nginx_waiting
+      thresholds:
+        - max: "30"
+          status: 1
   pipelines: []
 ---
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu-plugins-nginx:3.1.2
-  labels:
+  name: nginx-check:0.1.0
+  labels: 
   annotations:
-    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-nginx
-    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu-plugins/sensu-plugins-nginx
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/nginx-check
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/nginx-check
     io.sensu.bonsai.tier: Community
-    io.sensu.bonsai.version: 3.1.2
-    io.sensu.bonsai.namespace: sensu-plugins
-    io.sensu.bonsai.name: sensu-plugins-nginx
-    io.sensu.bonsai.tags: ''
-spec:
-  builds:
-    - url: https://assets.bonsai.sensu.io/13cbb463622e907593512c92cbc01193d61620c3/sensu-plugins-nginx_3.1.2_debian9_linux_amd64.tar.gz
-      sha512: 2cead3d49833e3c17f12c43f3033c36947b3926d1d7d32ad8208190e562d0be651f736601bf15d40ab1bcdc81c6a3784cb4d5ce9691cc0d5fe1098ed62064d45
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/13cbb463622e907593512c92cbc01193d61620c3/sensu-plugins-nginx_3.1.2_debian_linux_amd64.tar.gz
-      sha512: 14f1b9535c7e413a290825ee29548a8f31ac0d7c078894b6b49a3411f6930ac719caf9cc8bc622a7ce7d1f419255eb2ff8886cd8c7b1a7afbc340e5a726ee143
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform_family == 'debian'
-    - url: https://assets.bonsai.sensu.io/13cbb463622e907593512c92cbc01193d61620c3/sensu-plugins-nginx_3.1.2_centos7_linux_amd64.tar.gz
-      sha512: fb90e61d6ff4aa684bc8702cb93f802fe600d46fe5af0bbd9c54e6cde4418e62b0c648196d7eaa22627d01fd0b96128cf256eb78ae6a0ea1f1a2d666de4a1736
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform_family == 'rhel'
-        - entity.system.platform_version.split('.')[0] == '7'
-    - url: https://assets.bonsai.sensu.io/13cbb463622e907593512c92cbc01193d61620c3/sensu-plugins-nginx_3.1.2_centos6_linux_amd64.tar.gz
-      sha512: 194e8c657097a0b134886c5d9e4e94a929bb97a9d24c11be7341bc9875a29ab71a8b167f8ef27a20244ec3531decc39e0692a13f5f142e1027ecdf11e5a33abc
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform_family == 'rhel'
-        - entity.system.platform_version.split('.')[0] == '6'
-    - url: https://assets.bonsai.sensu.io/13cbb463622e907593512c92cbc01193d61620c3/sensu-plugins-nginx_3.1.2_alpine3.8_linux_amd64.tar.gz
-      sha512: 27a7c92a68f3836433ba2f24ca06e6d95ecbd57006069c03e760c3e86f48db13709587eb8811b975fa96def3894201371daf2d90e28acbf4286726db86087fbe
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform == 'alpine'
-    - url: https://assets.bonsai.sensu.io/13cbb463622e907593512c92cbc01193d61620c3/sensu-plugins-nginx_3.1.2_alpine_linux_amd64.tar.gz
-      sha512: 2a0d9c30ea364e7500c09d590419dffa0f013cefb166fdc10619adfb96c18aecfc634e5c9b173c6b324cd80912aae789380aa46d46c84b45b840855fcd7d1356
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform == 'alpine'
-        - entity.system.platform_version.split('.')[0] == '3'
----
-type: Asset
-api_version: core/v2
-metadata:
-  annotations:
-    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-ruby-runtime
-    io.sensu.bonsai.name: sensu-ruby-runtime
+    io.sensu.bonsai.version: 0.1.0
     io.sensu.bonsai.namespace: sensu
-    io.sensu.bonsai.tags: ""
-    io.sensu.bonsai.tier: Community
-    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
-    io.sensu.bonsai.version: 0.0.10
-  name: sensu/sensu-ruby-runtime:0.0.10
+    io.sensu.bonsai.name: nginx-check
+    io.sensu.bonsai.tags: proxy
 spec:
   builds:
-    - filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform_family == 'rhel'
-        - parseInt(entity.system.platform_version.split('.')[0]) == 6
-      sha512: cbee19124b7007342ce37ff9dfd4a1dde03beb1e87e61ca2aef606a7ad3c9bd0bba4e53873c07afa5ac46b0861967a9224511b4504dadb1a5e8fb687e9495304
-      url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos6_linux_amd64.tar.gz
-    - filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform_family == 'debian'
-      sha512: a28952fd93fc63db1f8988c7bc40b0ad815eb9f35ef7317d6caf5d77ecfbfd824a9db54184400aa0c81c29b34cb48c7e8c6e3f17891aaf84cafa3c134266a61a
-      url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_debian_linux_amd64.tar.gz
-    - filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform_family == 'rhel'
-        - parseInt(entity.system.platform_version.split('.')[0]) > 6
-      sha512: 338b88b568a3213fa234640da2e037d1487fc3c639bc62340f2fb71eac8af9a90566cffc768d15035406ac5c049350006d73f3a07ae15f9528e1c6a9af2944cb
-      url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz
-    - filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
-        - entity.system.platform == 'alpine'
-        - entity.system.platform_version.split('.')[0] == '3'
-      sha512: 8d768d1fba545898a8d09dca603457eb0018ec6829bc5f609a1ea51a2be0c4b2d13e1aa46139ecbb04873449e4c76f463f0bdfbaf2107caf37ab1c8db87d5250
-      url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_alpine_linux_amd64.tar.gz
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_linux_armv6.tar.gz
+    sha512: 6471e770fa4232068e1d96b2ad79529483b23dcae109932f095a3d1e59fa22410205c2eb63948e2651120b217b5bd908856d3cc318af803a45cc531c837a992e
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm'
+    - entity.system.arm_version == 6
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_linux_armv7.tar.gz
+    sha512: 714e777c214fd5a7210b67030eb761f5d8c7f8e9ba55f6a0d64872f43f27848eaf51c17bd7b3e3efbdc419d4e4754c6143c705b06ddd750009f8068872e5d35d
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm'
+    - entity.system.arm_version == 7
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_linux_arm64.tar.gz
+    sha512: cba9e2c32e67599ef27d54e4bd27d8bddaf761add2b8f0fa249f77d9738a2c8be10eb98c9db3607a7efb31c1e3a3ee5bd171a68446005d34e9b190930d23c0ac
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm64'
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_linux_386.tar.gz
+    sha512: d4ade495915a466e71e4c0a478678c4d1fb3d5e5f3c762ef24dbbec852536bdc795e29d4ee5694dd8186f353d89b5d25fbf67cebd82da12581dafcb21dc6d318
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == '386'
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_windows_amd64.tar.gz
+    sha512: 23366961702dc6251603fac6cf14567e678bf434e6117bc211d391de972347f2972191ab0defe1f5d89d0a0b0de9bf960deb1475803391370fe25e48408d50f4
+    filters:
+    - entity.system.os == 'windows'
+    - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_darwin_amd64.tar.gz
+    sha512: 28ffac29994139e7382ba77a996e295c3513ab36919987fafb8412eff7fd00da3f8f9334e7cf9775acf5357357bb2a380d6d1a61bb247f55bf17f6dfd11aeb2e
+    filters:
+    - entity.system.os == 'darwin'
+    - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/02bff14ff7f692daab5cace39dcc6e184751285a/nginx-check_0.1.0_linux_amd64.tar.gz
+    sha512: 981e3eb3c003a28c30f25ab147707314dfd247e2bd846444d3760978ab6dc2df7aa424bee1b0c6a3ec2b1b2afd951b09dfe9e5e95956afb005bc928f33f8d6e3
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+


### PR DESCRIPTION
This updates the existing NGINX integration to use the new official plugin (Go, metric-first), retiring the old plugin (Ruby, metrics/check).

That causes a number of small changes:
- removes the ruby runtime asset and updates the plugin asset to point to the new one
- replaces the `nginx-healthcheck` Check w/ output threshold against the `nginx-metrics` output
- outputs metrics in prometheus format
- adds prompts to allow the user to configure the warning thresholds
- adds changelog
- updates the readme

To test, I verified with local catalog harness and it seemed to function as expected.