### PR TITLE
Generate API from snapshots & publish

### DIFF
--- a/.github/actions/generate-catalog-api/action.yml
+++ b/.github/actions/generate-catalog-api/action.yml
@@ -5,12 +5,16 @@ author: 'sensu'
 inputs:
   catalog-api-version:
     description: 'The version of the API tool to use'
-    required: true
+    type: string
     default: '0.1.0-alpha.11'
+  snapshot:
+    description: 'Enables generation of the API from a snapshot'
+    type: boolean
+    default: false
   temp-dir:
     description: 'The path to a temp directory to store the generated API files'
-    required: true
-    default: 'tmp'
+    type: string
+    default: './tmp'
 outputs:
   release-dir:
     description: 'The path of the generated release directory'
@@ -20,6 +24,7 @@ runs:
   args:
     - ${{ inputs.catalog-api-version }}
     - ${{ inputs.temp-dir }}
+    - ${{ inputs.snapshot }}
 branding:
   icon: 'globe'
   color: 'green'

--- a/.github/actions/generate-catalog-api/entrypoint.sh
+++ b/.github/actions/generate-catalog-api/entrypoint.sh
@@ -4,8 +4,10 @@ catalog_api_version="$1"
 temp_dir="$2"
 snapshot="$3"
 
-echo "snapshot: ${snapshot}"
-exit 1
+args="--temp-dir ${temp_dir}"
+if [ $snapshot = "true" ]; then
+    args="${args} --snapshot"
+fi
 
 echo "Downloading & installing catalog-api"
 catalog_api_os="linux"
@@ -20,5 +22,5 @@ echo "Creating tmp directory for generated files"
 mkdir -p ./tmp
 
 echo "Generating Catalog API"
-catalog-api catalog generate --temp-dir "$temp_dir"
+catalog-api catalog generate $args
 chown -R 1001:1001 tmp

--- a/.github/actions/generate-catalog-api/entrypoint.sh
+++ b/.github/actions/generate-catalog-api/entrypoint.sh
@@ -2,6 +2,10 @@
 
 catalog_api_version="$1"
 temp_dir="$2"
+snapshot="$3"
+
+echo "snapshot: ${snapshot}"
+exit 1
 
 echo "Downloading & installing catalog-api"
 catalog_api_os="linux"

--- a/.github/actions/publish-catalog-api/entrypoint.sh
+++ b/.github/actions/publish-catalog-api/entrypoint.sh
@@ -5,6 +5,7 @@ echo "Publishing Catalog API"
 aws s3 cp "$1" "s3://${AWS_S3_BUCKET}" \
     --recursive \
     --exclude version.json \
+    --acl 'public-read' \
     --cache-control 'max-age=31104000' # 360 days
 
 aws s3 cp "${1}/version.json" "s3://${AWS_S3_BUCKET}" \

--- a/.github/workflows/sensu-catalog-production.yml
+++ b/.github/workflows/sensu-catalog-production.yml
@@ -7,7 +7,7 @@ on:
       - '*/*/*'
 
 jobs:
-  run:
+  production:
     uses: ./.github/workflows/sensu-catalog.yml
     secrets:
       aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/sensu-catalog-production.yml
+++ b/.github/workflows/sensu-catalog-production.yml
@@ -1,0 +1,16 @@
+---
+name: 'Sensu Catalog Workflow (Production)'
+
+on:
+  push:
+    tags:
+      - '*/*/*'
+
+jobs:
+  run:
+    uses: ./.github/workflows/sensu-catalog.yml
+    secrets:
+      aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws_region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/sensu-catalog-staging.yml
+++ b/.github/workflows/sensu-catalog-staging.yml
@@ -1,0 +1,18 @@
+---
+name: 'Sensu Catalog Workflow (Staging)'
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  run:
+    uses: ./.github/workflows/sensu-catalog.yml
+    with:
+      catalog_snapshot: true
+    secrets:
+      aws_s3_bucket: ${{ secrets.STAGING_AWS_S3_BUCKET }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws_region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/sensu-catalog-staging.yml
+++ b/.github/workflows/sensu-catalog-staging.yml
@@ -7,7 +7,7 @@ on:
       - '**'
 
 jobs:
-  run:
+  staging:
     uses: ./.github/workflows/sensu-catalog.yml
     with:
       catalog_snapshot: true

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -1,10 +1,31 @@
 ---
 name: 'Sensu Catalog Workflow'
-on: [push, pull_request]
-env:
-  cache_key: ${{ github.workflow }}-${{ github.run_number }}-${{ github.run_attempt }}
-  catalog_api_version: 0.1.0-alpha.11
-  catalog_temp_dir: ./tmp
+
+on:
+  workflow_call:
+    inputs:
+      cache_key:
+        type: string
+        default: |
+          ${{ github.workflow }}-${{ github.run_number }}-${{ github.run_attempt }}
+      catalog_api_version:
+        type: string
+        default: '0.1.0-alpha.11'
+      catalog_temp_dir:
+        type: string
+        default: './tmp'
+      catalog_snapshot:
+        type: boolean
+        default: false
+    secrets:
+      aws_s3_bucket:
+        required: true
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      aws_region:
+        required: true
 
 jobs:
   validate:
@@ -17,12 +38,11 @@ jobs:
       - name: Run Sensu Catalog validation
         uses: ./.github/actions/validate-catalog
         with:
-          catalog-api-version: ${{ env.catalog_api_version }}
+          catalog-api-version: ${{ inputs.catalog_api_version }}
 
   generate:
     name: 'Generate Sensu Catalog API'
     runs-on: ubuntu-latest
-    if: contains(fromJson('["push", "create"]'), github.event_name) && contains(github.ref, 'refs/tags/')
     needs: validate
     outputs:
       release-dir: ${{ steps.generate-api.outputs.release-dir }}
@@ -33,14 +53,15 @@ jobs:
       - name: Setup Cache
         uses: actions/cache@v2
         with:
-          path: ${{ env.catalog_temp_dir }}
-          key: ${{ env.cache_key }}
+          path: ${{ inputs.catalog_temp_dir }}
+          key: ${{ inputs.cache_key }}
       - name: Run Sensu Catalog API generation
         uses: ./.github/actions/generate-catalog-api
         id: generate-api
         with:
-          catalog-api-version: ${{ env.catalog_api_version }}
-          temp-dir: ${{ env.catalog_temp_dir }}
+          catalog-api-version: ${{ inputs.catalog_api_version }}
+          snapshot: ${{ inputs.catalog_snapshot }}
+          temp-dir: ${{ inputs.catalog_temp_dir }}
 
   publish:
     name: 'Publish Sensu Catalog API'
@@ -53,8 +74,8 @@ jobs:
       - name: Restore Cache
         uses: actions/cache@v2
         with:
-          path: ${{ env.catalog_temp_dir }}
-          key: ${{ env.cache_key }}
+          path: ${{ inputs.catalog_temp_dir }}
+          key: ${{ inputs.cache_key }}
       - name: Run Sensu Catalog API publisher
         uses: ./.github/actions/publish-catalog-api
         with:


### PR DESCRIPTION
This will generate a static API using the `-snapshot` flag for each push to GitHub. The generated API will then be uploaded to a new staging bucket in S3 for us to test.

Closes #128 but does not implement a promotion process as we need tags to determine versions. Creating a tag will continue to generate & publish a static API.