### PR TITLE
Allow version filename to be overidden

### DIFF
--- a/.github/actions/publish-catalog-api/action.yml
+++ b/.github/actions/publish-catalog-api/action.yml
@@ -6,11 +6,15 @@ inputs:
   release-dir:
     description: 'The path to the generated release directory'
     required: true
+  version-file:
+    description: 'The name of the version file to generate'
+    default: 'version.json'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.release-dir }}
+    - ${{ inputs.version-file }}
 branding:
   icon: 'globe'
   color: 'green'

--- a/.github/actions/publish-catalog-api/entrypoint.sh
+++ b/.github/actions/publish-catalog-api/entrypoint.sh
@@ -2,12 +2,17 @@
 
 echo "Publishing Catalog API"
 
-aws s3 cp "$1" "s3://${AWS_S3_BUCKET}" \
+release_dir="$1"
+version_file="$2"
+
+# all files except version file
+aws s3 cp "$release_dir" "s3://${AWS_S3_BUCKET}" \
     --recursive \
-    --exclude version.json \
+    --exclude "$version_file" \
     --acl 'public-read' \
     --cache-control 'max-age=31104000' # 360 days
 
-aws s3 cp "${1}/version.json" "s3://${AWS_S3_BUCKET}" \
+# version file
+aws s3 cp "${release_dir}/version.json" "s3://${AWS_S3_BUCKET}/${version_file}" \
     --cache-control 'no-cache' \
     --acl 'public-read'

--- a/.github/workflows/sensu-catalog-staging.yml
+++ b/.github/workflows/sensu-catalog-staging.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/sensu-catalog.yml
     with:
       catalog_snapshot: true
+      catalog_version_file: ${{ github.sha }}.json
     secrets:
       aws_s3_bucket: ${{ secrets.STAGING_AWS_S3_BUCKET }}
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/sensu-catalog.yml
+++ b/.github/workflows/sensu-catalog.yml
@@ -17,6 +17,8 @@ on:
       catalog_snapshot:
         type: boolean
         default: false
+      catalog_version_file:
+        type: string
     secrets:
       aws_s3_bucket:
         required: true
@@ -80,6 +82,7 @@ jobs:
         uses: ./.github/actions/publish-catalog-api
         with:
           release-dir: ${{ needs.generate.outputs.release-dir }}
+          version-file: ${{ inputs.catalog_version_file }}
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Allow the version filename to be overridden. Staging will override `version.json` to `<git-commit-sha>.json` by default.