### PR TITLE
Ask users for secrets, store them as configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,14 +473,6 @@ Please note the following guidelines for comopsing Sensu Integration:
    * Secret(s)
    * Asset(s)
 
-1. Take care to maintain secrets.
-   If a resource makes use of a secret and the command supports using built-in enviornment variables for that secret, avoid exposing it unnecessarily with a command argument.
-   For example, the InfluxDB handler has arguments for providing a username (-u) and password (-p).
-   It also supports specifying those as the environment variables `INFLUXDB_USER` and `INFLUXDB_PASSWORD`, respectively.
-   In this case the command should avoid using the arguments and instead use the environment variables.
-
-1. Secrets should be created using the built-in `env` provider.
-
 1. For alert and incident-management handlers avoid the use of filters that have highly subjective configuration options.
    By default, use the built-in `is_incident` and `not_silenced` filters.
    However, we do encourage you to share your filters, as appropriate in the `shared` directory.

--- a/integrations/ansible/ansible-tower-remediation/README.md
+++ b/integrations/ansible/ansible-tower-remediation/README.md
@@ -10,8 +10,6 @@ This integration includes the following resources:
 
 * `ansible-tower` ([pipeline])
 * `ansible-tower` ([handler])
-* `ansible_tower_host` ([secret])
-* `ansible_tower_token` ([secret])
 * `sensu/sensu-ansible-handler:2.1.0` ([asset])
 
 ## Dashboards
@@ -32,15 +30,6 @@ This integration is compatible with the [Ansible Tower Jobs dashboard][ansible-t
    [Create an application using the Ansible Tower admin console][ansible-tower-application].
 
    [Create an application OAuth token using the Ansble Tower admin console][ansible-tower-app-token].
-
-1. Configure Secrets Management
-
-   This integration requires the following [Sensu Secrets][secrets]:
-
-   - `ansible_tower_host` (hostname or IP address of the Ansible Tower API)
-   - `ansible_tower_token` (Ansible Tower application OAuth token)
-
-   _NOTE: this integration creates one or more Sensu Secrets using the "env" provider. The corresponding environment variables need to be set on every sensu-backend in the Sensu deployment. To add the environment variables, please modify `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` and restart the sensu-backend service(s)._
 
 1. Add a `io.sensu.ansible.config.actions` ("remediation action") [annotation] to one or more checks.
 
@@ -108,8 +97,6 @@ This integration does not produce any events that should be processed by an aler
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [sensu-plus]: https://sensu.io/features/analytics

--- a/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-integration.yaml
@@ -28,8 +28,6 @@ spec:
         Please visit [Ansible Tower API OAuth Guide] for more information.
 
         [Ansible Tower API OAuth Guide]: https://docs.ansible.com/ansible-tower/latest/html/administration/oauth2_token_auth.html
-    - type: section
-      title: Ansible Tower API Configuration
     - type: question
       name: api_host
       required: true
@@ -40,24 +38,13 @@ spec:
           Provide the API Host (i.e. hostname or IP address)
         default: "127.0.0.1"
     - type: question
-      name: api_token_secret_provider
+      name: ansible_tower_api_token
+      required: true
       input:
         type: string
-        title: API Token Secret Provider
+        title: Ansible Tower API Token
         description: >-
-          Select the API Token secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: api_token_secret_id
-      input:
-        type: string
-        title: Secret ID
-        description: >-
-          Provide the API Token secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_ANSIBLE_TOWER_TOKEN
+          Ansible Tower API Token
   resource_patches:
     - resource:
         api_version: core/v2
@@ -67,14 +54,6 @@ spec:
         - path: /spec/env_vars/0
           op: replace
           value: ANSIBLE_HOST=127.0.0.1
-    - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: ansible_tower_token
-      patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[api_token_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[api_token_secret_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "ANSIBLE_TOKEN=[[ansible_tower_api_token]]"

--- a/integrations/ansible/ansible-tower-remediation/sensu-resources.yaml
+++ b/integrations/ansible/ansible-tower-remediation/sensu-resources.yaml
@@ -19,23 +19,15 @@ metadata:
   name: ansible-tower
 spec:
   type: pipe
-  command: sensu-ansible-handler --host ${ANSIBLE_HOST}
+  command: >-
+    sensu-ansible-handler 
+    --host ${ANSIBLE_HOST}
+    # NOTE: Requires ANSIBLE_TOKEN environment variable or secret
   runtime_assets:
     - sensu/sensu-ansible-handler:2.1.0
   timeout: 10
   env_vars:
     - ANSIBLE_HOST=127.0.0.1
-  secrets:
-    - name: ANSIBLE_TOKEN
-      secret: ansible_tower_token
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: ansible_tower_token
-spec:
-  provider: env
-  id: SENSU_ANSIBLE_TOWER_TOKEN
 ---
 type: Asset
 api_version: core/v2

--- a/integrations/cassandra/cassandra-monitoring/README.md
+++ b/integrations/cassandra/cassandra-monitoring/README.md
@@ -149,8 +149,6 @@ This integration collects the following [metrics] (in [Graphite format][graphite
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [sensu-plus]: https://sensu.io/features/analytics
 <!-- [{{dashboard-link}}]: # -->

--- a/integrations/mattermost/mattermost-alerts/README.md
+++ b/integrations/mattermost/mattermost-alerts/README.md
@@ -10,8 +10,6 @@ This integration provides the following resources:
 
 * `mattermost` [pipeline]
 * `slack` [handler]
-* `mattermost_webhook_url` [secrets]
-* `mattermost_channel` [secrets]
 * `sensu/sensu-slack-handler` [asset]
 
 ## Dashboards
@@ -31,15 +29,6 @@ The handler will send event data to a channel to your Mattermost instance.
 1. Get a Mattermost Webhook URL
 
    To obtain a [Mattermost Webhook URL][mattermost-webhook-url], please enable Incoming Webhooks for the Mattermost application Sensu will be using to send alert messages. 
-
-1. Configure Secrets Management 
-
-   This integration requires the following [Sensu Secrets][secrets]: 
-
-   - `mattermost_webhook_url`
-   - `mattermost_channel`
-
-   _NOTE: this integration creates one or more Sensu Secrets using the "env" provider. The corresponding environment variables need to be set on every sensu-backend in the Sensu deployment. To add the environment variables, please modify `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` and restart the sensu-backend service(s)._
 
 ## Plugins
 
@@ -74,7 +63,6 @@ This integration does not produce any events that should be processed by an aler
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [mattermost-webhook-url]: https://docs.mattermost.com/developer/webhooks-incoming.html
 [slack-plugin-bonsai]: https://bonsai.sensu.io/assets/sensu/sensu-slack-handler
 [slack-plugin-github]: https://github.com/sensu/sensu-slack-handler

--- a/integrations/mattermost/mattermost-alerts/sensu-integration.yaml
+++ b/integrations/mattermost/mattermost-alerts/sensu-integration.yaml
@@ -18,7 +18,7 @@ spec:
     - "@jspaleta"
   prompts:
     - type: section
-      title: Mattermost Secrets
+      title: Mattermost Configuration
     - type: markdown
       body: |
         This integration requires a Mattermost Webhook URL for Mattermost API Authentication, and a default alerting channel.
@@ -27,68 +27,32 @@ spec:
 
         [Mattermost Incoming Webhook]: https://docs.mattermost.com/developer/webhooks-incoming.html
         [Mattermost Channels]: https://docs.mattermost.com/guides/channels.html
-    - type: section
-      title: Mattermost Webhook URL
     - type: question
-      name: webhook_url_secret_provider
+      name: mattermost_webhook_url
+      required: true
       input:
         type: string
-        title: Webhook URL Secret Provider
+        title: Mattermost Webhook URL
         description: >-
-          Select the Webhook URL secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
+          Mattermost Webhook URL
     - type: question
-      name: webhook_url_secret_id
+      name: mattermost_channel
+      required: true
       input:
         type: string
-        title: Secret ID
+        title: Mattermost Channel
         description: >-
-          Provide the Webhook URL secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_MATTERMOST_WEBHOOK_URL
-    - type: section
-      title: Mattermost Channel
-    - type: question
-      name: channel_secret_provider
-      input:
-        type: string
-        title: Channel Secret Provider
-        description: >-
-          Select the Channel secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: channel_secret_id
-      input:
-        type: string
-        title: Secret ID
-        description: >-
-          Provide the Channel secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_MATTERMOST_CHANNEL
+          Mattermost Channel (e.g. #alerts)
+        default: "#alerts"
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: mattermost_webhook_url
+        api_version: core/v2
+        type: Handler
+        name: mattermost
       patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[webhook_url_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[webhook_url_secret_id]]"
-    - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: mattermost_channel
-      patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[channel_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[channel_secret_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "MATTERMOST_WEBHOOK_URL=[[mattermost_webhook_url]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "MATTERMOST_CHANNEL=[[mattermost_channel]]"

--- a/integrations/mattermost/mattermost-alerts/sensu-resources.yaml
+++ b/integrations/mattermost/mattermost-alerts/sensu-resources.yaml
@@ -15,6 +15,9 @@ spec:
         - api_version: core/v2
           type: EventFilter
           name: not_silenced
+        - api_version: core/v2
+          type: EventFilter
+          name: mattermost_alerts
       handler:
         api_version: core/v2
         type: Handler
@@ -31,31 +34,20 @@ spec:
     --channel ${MATTERMOST_CHANNEL}
     --username SensuGo
     --webhook-url ${MATTERMOST_WEBHOOK_URL}
-    --description-template "{{ .Check.Output }}\n\n[namespace: {{.Entity.Namespace}}]"
+    --description-template "{{ .Check.Output }}\n\n[namespace: {{ .Entity.Namespace }}]"
   runtime_assets:
     - sensu/sensu-slack-handler:1.4.0
   timeout: 0
-  secrets:
-    - name: MATTERMOST_WEBHOOK_URL
-      secret: mattermost_webhook_url
-    - name: MATTERMOST_CHANNEL
-      secret: mattermost_channel
+  env_vars: []
 ---
-type: Secret
-api_version: secrets/v1
+type: EventFilter
+api_version: core/v2
 metadata:
-  name: mattermost_webhook_url
+  name: mattermost_alerts
 spec:
-  provider: env
-  id: SENSU_MATTERMOST_WEBHOOK_URL
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: mattermost_channel
-spec:
-  provider: env
-  id: SENSU_MATTERMOST_CHANNEL
+  action: allow
+  expressions:
+  - event.check.occurrences == 1 || Math.ceil( seconds_since(event.check.last_ok) / 60 ) % 60 == 0
 ---
 type: Asset
 api_version: core/v2

--- a/integrations/microsoft-teams/microsoft-teams-alerts/README.md
+++ b/integrations/microsoft-teams/microsoft-teams-alerts/README.md
@@ -10,9 +10,7 @@ This integration provides the following resources:
 
 * `microsoft-teams` [pipeline]
 * `microsoft-teams` [handler]
-* `microsoft_teams_webhook_url` [secrets]
 * `sensu/sensu-microsoft-teams-handler:0.1.2` [asset]
-
 
 ## Dashboards
 
@@ -31,14 +29,6 @@ There are no known supported dashboards for this integration.
 1. Get a Microsoft Teams webhook url
 
    To obtain a [Teams Webhook URL][microsoft-teams-webhook-url], please add an Incoming Webhook for the Teams channel that Sensu will be using to send alert messages. 
-
-1. Configure secrets management 
-
-   This integration requires the following [Sensu Secrets][secrets]: 
-
-   - `microsoft_teams_webhook_url`
-
-   _NOTE: this integration creates one or more Sensu Secrets using the "env" provider. The corresponding environment variables need to be set on every sensu-backend in the Sensu deployment. To add the environment variables, please modify `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` and restart the sensu-backend service(s)._
 
 ## Plugins
 
@@ -71,7 +61,6 @@ This integration does not produce any events that should be processed by an aler
 [annotation]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [plugins]: https://docs.sensu.io/sensu-go/latest/plugins/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/

--- a/integrations/microsoft-teams/microsoft-teams-alerts/sensu-integration.yaml
+++ b/integrations/microsoft-teams/microsoft-teams-alerts/sensu-integration.yaml
@@ -19,7 +19,7 @@ spec:
     - "@nixwiz"
   prompts:
     - type: section
-      title: Microsoft Teams Secrets
+      title: Microsoft Teams Configuration
     - type: markdown
       body: |
         This integration requires a Microsoft Teams Webhook URL for Microsoft Teams API Authentication.
@@ -27,36 +27,20 @@ spec:
         Please visit [Microsoft Teams Incoming Webhook] documentation for more information.
 
         [Microsoft Teams Incoming Webhook]: https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook
-    - type: section
-      title: Microsoft Teams Webhook URL
     - type: question
-      name: webhook_url_secret_provider
+      name: microsoft_teams_webhook_url
+      required: true
       input:
         type: string
-        title: Webhook URL Secret Provider
+        title: Microsoft Teams Webhook URL
         description: >-
-          Select the Webhook URL secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: webhook_url_secret_id
-      input:
-        type: string
-        title: Secret ID
-        description: >-
-          Provide the Webhook URL secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_MICROSOFT_TEAMS_WEBHOOK_URL
+          Microsoft Teams Webhook URL
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: microsoft_teams_webhook_url
+        api_version: core/v2
+        type: Handler
+        name: microsoft-teams
       patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[webhook_url_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[webhook_url_secret_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "MICROSOFT_TEAMS_WEBHOOK_URL=[[microsoft_teams_webhook_url]]"

--- a/integrations/microsoft-teams/microsoft-teams-alerts/sensu-resources.yaml
+++ b/integrations/microsoft-teams/microsoft-teams-alerts/sensu-resources.yaml
@@ -29,21 +29,11 @@ spec:
     sensu-microsoft-teams-handler
     --icon-url https://www.sensu.io/img/sensu-logo.png
     --title-template "Sensu Event - {{.Entity.Name}}/{{.Check.Name}}"
+    # NOTE: Requires MICROSOFT_TEAMS_WEBHOOK_URL environment variable or secret
   runtime_assets:
-  - sensu/sensu-microsoft-teams-handler:0.1.2
-  secrets:
-  - name: MICROSOFT_TEAMS_WEBHOOK_URL
-    secret: microsoft_teams_webhook_url
+    - sensu/sensu-microsoft-teams-handler:0.1.2
   timeout: 0
   type: pipe
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: microsoft_teams_webhook_url
-spec:
-  provider: env
-  id: SENSU_MICROSOFT_TEAMS_WEBHOOK_URL
 ---
 type: Asset
 api_version: core/v2

--- a/integrations/pagerduty/pagerduty-incidents/README.md
+++ b/integrations/pagerduty/pagerduty-incidents/README.md
@@ -10,7 +10,6 @@ This integration provides the following resources:
 
 * `pagerduty` [pipeline]
 * `pagerduty` [handler]
-* `pagerduty_integration_key` [secret]
 * `sensu/sensu-pagerduty-handler:2.1.0` [asset]
 
 ## Dashboards
@@ -30,10 +29,6 @@ This integration is compatible with the [Pagerduty Incidents] dashboard. The Inc
 1. **Get a Pagerduty Integration Key**
 
    To obtain a [Pagerduty Integration Key][pagerduty-integration-key], please visit your Pagerduty dashboard, browse to "Automation" > "Event Rules", and copy your Pagerduty "Integration Key".
-
-1. **Add the Pagerduty Integration Key to your secrets provider**
-
-   Create an environment variable or Hashicorp Vault secret for the Pagerduty Integration Key.
 
 ## Plugins
 
@@ -61,7 +56,6 @@ This integration does not produce any events that should be processed by an aler
 
 1. Pagerduty knowledge base: ["Generate an Integration Key"][pagerduty-integration-key]
 1. This integration uses [Handler Templating][handler-templating] for variable substitution
-1. This integration uses Sensu's built-in [Secrets Management][secrets-mgmt]
 
 <!-- Links -->
 [check]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/checks/
@@ -75,8 +69,6 @@ This integration does not produce any events that should be processed by an aler
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets-mgmt]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets-management/
 [pagerduty-integration-key]: https://support.pagerduty.com/docs/services-and-integrations#generate-a-new-integration-key
 [pagerduty-plugin-bonsai]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [pagerduty-plugin-github]: https://github.com/sensu/sensu-pagerduty-handler

--- a/integrations/pagerduty/pagerduty-incidents/sensu-integration.yaml
+++ b/integrations/pagerduty/pagerduty-incidents/sensu-integration.yaml
@@ -21,7 +21,7 @@ spec:
     - "@thoward"
   prompts:
     - type: section
-      title: Pagerduty Integration Key
+      title: Pagerduty Configuration
     - type: markdown
       body: |
         This integration requires a Pagerduty Integration Key for Pagerduty API Authentication.
@@ -30,31 +30,17 @@ spec:
 
         ["Generate an Integration Key"]: https://support.pagerduty.com/docs/services-and-integrations#generate-a-new-integration-key
     - type: question
-      name: secret_provider
+      name: pagerduty_token
+      required: true
       input:
         type: string
-        title: Secret Provider
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: secret_id
-      input:
-        type: string
-        title: Secret ID
-        description: >-
-          Provide the Secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: PAGERDUTY_INTEGRATION_KEY
+        title: Pagerduty Integration Key
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: pagerduty_integration_key
+        api_version: core/v2
+        type: Handler
+        name: pagerduty
       patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[secret_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "PAGERDUTY_TOKEN=[[pagerduty_token]]"

--- a/integrations/pagerduty/pagerduty-incidents/sensu-resources.yaml
+++ b/integrations/pagerduty/pagerduty-incidents/sensu-resources.yaml
@@ -31,21 +31,12 @@ spec:
     --status-map "{\"info\":[0],\"warning\": [1],\"critical\": [2],\"error\": [3,127]}"
     --summary-template "[{{.Entity.Namespace}}] {{.Entity.Name}}/{{.Check.Name}}: {{.Check.State}}"
     --details-template "{{.Check.Output}}\n\n{{.Check}}"
+    # NOTE: Requires PAGERDUTY_TOKEN environment variable or secret
   runtime_assets:
     - sensu/sensu-pagerduty-handler:2.1.0
-  secrets:
-    - name: PAGERDUTY_TOKEN
-      secret: pagerduty_integration_key
+  env_vars: []
   timeout: 0
   type: pipe
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: pagerduty_integration_key
-spec:
-  provider: env
-  id: PAGERDUTY_INTEGRATION_KEY
 ---
 type: Asset
 api_version: core/v2

--- a/integrations/sensu/platform-discovery/README.md
+++ b/integrations/sensu/platform-discovery/README.md
@@ -79,7 +79,7 @@ This integration does not produce any metrics.
 This integration does not produce any alerts.
 Discovery events are processed via the `entity-manager` pipeline, which updates entity subscriptions in real-time.
 
-_NOTE: the default filters on the provided pipeline will only process the first discovery event produced by the discovery check; to trigger a subsequent entity update (e.g. if the API Key secret was initially invalid), simply delete the platform-discovery event for a given entity. The next time the check runs, the entity subscription update will be applied again._
+_NOTE: the default filters on the provided pipeline will only process the first discovery event produced by the discovery check; to trigger a subsequent entity update (e.g. if the API Key was initially invalid), simply delete the platform-discovery event for a given entity. The next time the check runs, the entity subscription update will be applied again._
 
 ## Reference Documentation
 
@@ -99,8 +99,6 @@ _NOTE: the default filters on the provided pipeline will only process the first 
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [sensu-plus]: https://sensu.io/features/analytics
 [sensu-platform-discovery-bonsai]: https://bonsai.sensu.io/assets/sensu/sensu-platform-discovery

--- a/integrations/sensu/platform-discovery/sensu-integration.yaml
+++ b/integrations/sensu/platform-discovery/sensu-integration.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   class: supported
   provider: discovery
-  display_name: Platform Discovery 
+  display_name: Platform Discovery
   short_description: Platform auto-discovery adds agent OS/platform subscription(s).
   supported_platforms:
     - darwin
@@ -18,9 +18,10 @@ spec:
     - auto-discovery
   contributors:
     - "@sensu"
+    - "@calebhailey"
   prompts:
     - type: section
-      title: Secrets Management
+      title: Sensu API Configuration
     - type: markdown
       body: |
         This integration includes a check for collecting Agent OS/platform metadata, and a pipeline for updating agent subscriptions.
@@ -29,31 +30,19 @@ spec:
 
         [pipelines]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/
     - type: question
-      name: secret_provider
+      name: sensu_api_key
+      required: true
       input:
         type: string
-        title: Secret Provider
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: secret_id
-      input:
-        type: string
-        title: Secret ID
+        title: Sensu API Key
         description: >-
-          Provide the Secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_ENTITY_MANAGER_API_KEY
+          Sensu API Key (requires entity "update" permissions in the corresponding role)
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: entity-manager-api-key
+        api_version: core/v2
+        type: Handler
+        name: subscription-manager
       patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[secret_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "SENSU_API_KEY=[[sensu_api_key]]"

--- a/integrations/sensu/platform-discovery/sensu-resources.yaml
+++ b/integrations/sensu/platform-discovery/sensu-resources.yaml
@@ -10,16 +10,16 @@ metadata:
 spec:
   command: sensu-platform-discovery
   runtime_assets:
-  - sensu/sensu-platform-discovery:0.0.2
+    - sensu/sensu-platform-discovery:0.0.2
   subscriptions:
-  - autodiscovery
+    - autodiscovery
   publish: true
   interval: 60
   timeout: 5
   pipelines:
-  - api_version: core/v2
-    type: Pipeline
-    name: entity-manager
+    - api_version: core/v2
+      type: Pipeline
+      name: entity-manager
 
 ---
 type: Pipeline
@@ -30,15 +30,15 @@ metadata:
     provider: discovery
 spec:
   workflows:
-  - name: subscription-manager
-    filters:
-    - api_version: core/v2
-      type: EventFilter
-      name: has_subscriptions
-    handler:
-      api_version: core/v2
-      type: Handler
-      name: subscription-manager
+    - name: subscription-manager
+      filters:
+        - api_version: core/v2
+          type: EventFilter
+          name: has_subscriptions
+      handler:
+        api_version: core/v2
+        type: Handler
+        name: subscription-manager
 
 ---
 type: Handler
@@ -48,16 +48,14 @@ metadata:
 spec:
   type: pipe
   command: >-
-    sensu-entity-manager
+    sensu-entity-manager 
     --add-subscriptions
+    # NOTE: Requires SENSU_API_KEY environment variable or secret
   runtime_assets:
-  - sensu/sensu-entity-manager:0.3.0
+    - sensu/sensu-entity-manager:0.3.0
   timeout: 5
   env_vars:
-  - SENSU_API_URL=http://127.0.0.1:8080
-  secrets:
-  - name: SENSU_API_KEY
-    secret: entity-manager-api-key
+    - SENSU_API_URL=http://127.0.0.1:8080
 
 ---
 type: EventFilter
@@ -67,18 +65,9 @@ metadata:
 spec:
   action: allow
   expressions:
-  - event.check.annotations.discovery == "subscriptions"
-  - event.check.status == 0
-  - event.check.occurrences == 1
-
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: entity-manager-api-key
-spec:
-  provider: env
-  id: SENSU_ENTITY_MANAGER_API_KEY
+    - event.check.annotations.discovery == "subscriptions"
+    - event.check.status == 0
+    - event.check.occurrences == 1
 
 ---
 type: Asset
@@ -95,36 +84,36 @@ metadata:
     io.sensu.bonsai.tags: check, discovery
 spec:
   builds:
-  - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_armv7.tar.gz
-    sha512: 763633eb186cd5eb37df668a71dabb57aee9300a6c88402c3dfe5ee8acc6769516b9428dbf3ac51cd269bb2cfedead736ed0f16b705abf07e946a33ae0f59fdc
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == 'armv7'
-  - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_windows_amd64.tar.gz
-    sha512: 5dd9603dd6035470946f2cc6826bb0717a910bd61d2dbb377004bae9b2780bc731b53850963eb5cf5ebc35cfdbcf3f4f8b710c2b4c9329ba5be0535db6f8a206
-    filters:
-    - entity.system.os == 'windows'
-    - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_darwin_amd64.tar.gz
-    sha512: fa4ae4e9adbab8ca333135a207cd046298d92a7515c84bec48ab3674ce3c0560da9b061b52b103387f93a5889d8a1859c20efd75600587894f39735532fdb331
-    filters:
-    - entity.system.os == 'darwin'
-    - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_arm64.tar.gz
-    sha512: 156da9ada1670c89dcf07235c52810927d99e89a03feb14c62d713d8ecec2abe41e824d334921ab89198ce1c73cc0491201c58106332472c0e035e5912ef5b0b
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == 'arm64'
-  - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_386.tar.gz
-    sha512: f5ac7389f090fe3eeaa95efcdf1d5ead3055f6924ae6a2f6574e108a8d6fce3b1d953d6faea16a5241b5100041fa0200766f4b247b494904ad7a80f78d7d53d8
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == '386'
-  - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_amd64.tar.gz
-    sha512: 8ccca40abd6025555b15f110f2bdbcc89841a752e014990eaf4d90380ae5540ec1aba471f7bfa52a71cb5cb368b5a7fb8cea1d283220843e2f49e66584749baa
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == 'amd64'
+    - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_armv7.tar.gz
+      sha512: 763633eb186cd5eb37df668a71dabb57aee9300a6c88402c3dfe5ee8acc6769516b9428dbf3ac51cd269bb2cfedead736ed0f16b705abf07e946a33ae0f59fdc
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == 'armv7'
+    - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_windows_amd64.tar.gz
+      sha512: 5dd9603dd6035470946f2cc6826bb0717a910bd61d2dbb377004bae9b2780bc731b53850963eb5cf5ebc35cfdbcf3f4f8b710c2b4c9329ba5be0535db6f8a206
+      filters:
+        - entity.system.os == 'windows'
+        - entity.system.arch == 'amd64'
+    - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_darwin_amd64.tar.gz
+      sha512: fa4ae4e9adbab8ca333135a207cd046298d92a7515c84bec48ab3674ce3c0560da9b061b52b103387f93a5889d8a1859c20efd75600587894f39735532fdb331
+      filters:
+        - entity.system.os == 'darwin'
+        - entity.system.arch == 'amd64'
+    - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_arm64.tar.gz
+      sha512: 156da9ada1670c89dcf07235c52810927d99e89a03feb14c62d713d8ecec2abe41e824d334921ab89198ce1c73cc0491201c58106332472c0e035e5912ef5b0b
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == 'arm64'
+    - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_386.tar.gz
+      sha512: f5ac7389f090fe3eeaa95efcdf1d5ead3055f6924ae6a2f6574e108a8d6fce3b1d953d6faea16a5241b5100041fa0200766f4b247b494904ad7a80f78d7d53d8
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == '386'
+    - url: https://assets.bonsai.sensu.io/4501f0031e91f5a2a4c565ecd92fd594b0ceb3b6/sensu-platform-discovery_0.0.2_linux_amd64.tar.gz
+      sha512: 8ccca40abd6025555b15f110f2bdbcc89841a752e014990eaf4d90380ae5540ec1aba471f7bfa52a71cb5cb368b5a7fb8cea1d283220843e2f49e66584749baa
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == 'amd64'
 
 ---
 type: Asset
@@ -141,33 +130,33 @@ metadata:
     io.sensu.bonsai.tags: ''
 spec:
   builds:
-  - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_windows_amd64.tar.gz
-    sha512: d1fd35b6d2d2a6689678bbb019b1112402e07a01359a90196e7f50d1f1c0a1f03718428719c63ccc7cd4cb204a469a4e2a80392ece3b34398ce19780939bcd2c
-    filters:
-    - entity.system.os == 'windows'
-    - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_darwin_amd64.tar.gz
-    sha512: c34060958fa93286c0efec868211f8a2e43bc8360fb7fd6c6eaf6a8662b64804907dd95ce7ed3e7ececb4346126056245fda99b7dba15473be4e9fc592b8367f
-    filters:
-    - entity.system.os == 'darwin'
-    - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_armv7.tar.gz
-    sha512: 61ba6a0e5986279363e7b5fad286e82a042f39e211350de5b0a383caff1c335cd739cd0b4aa243aa2d0614b431577fe6b2e584bc471edbc08b43d5e1189611f0
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == 'armv7'
-  - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_arm64.tar.gz
-    sha512: 0457f23df027d4b844da55d378cd3d563ae0df58dd3e6eb00916292fa5284988a00f98c247a31fe96f49175b99b4f6aa7369c5ab7e57b4f9e474d242499ab3b8
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == 'arm64'
-  - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_386.tar.gz
-    sha512: 4a75f931dd058405e3cde3e93d1174cd11aa7c422fd517e63f04e1dc6121280f16496b2a62f3e25a6ecdfc168ba4d746cd31b2beef7c1714f4addeb8d263efd0
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == '386'
-  - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_amd64.tar.gz
-    sha512: 3f0d7967489edae1d181424483884c2d2fd4ec382d53a288e796768a0a88642e1136699ad8089e1cce67071acf5d2270f8137ada40abd308fa48ba3537bd8e3a
-    filters:
-    - entity.system.os == 'linux'
-    - entity.system.arch == 'amd64'
+    - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_windows_amd64.tar.gz
+      sha512: d1fd35b6d2d2a6689678bbb019b1112402e07a01359a90196e7f50d1f1c0a1f03718428719c63ccc7cd4cb204a469a4e2a80392ece3b34398ce19780939bcd2c
+      filters:
+        - entity.system.os == 'windows'
+        - entity.system.arch == 'amd64'
+    - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_darwin_amd64.tar.gz
+      sha512: c34060958fa93286c0efec868211f8a2e43bc8360fb7fd6c6eaf6a8662b64804907dd95ce7ed3e7ececb4346126056245fda99b7dba15473be4e9fc592b8367f
+      filters:
+        - entity.system.os == 'darwin'
+        - entity.system.arch == 'amd64'
+    - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_armv7.tar.gz
+      sha512: 61ba6a0e5986279363e7b5fad286e82a042f39e211350de5b0a383caff1c335cd739cd0b4aa243aa2d0614b431577fe6b2e584bc471edbc08b43d5e1189611f0
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == 'armv7'
+    - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_arm64.tar.gz
+      sha512: 0457f23df027d4b844da55d378cd3d563ae0df58dd3e6eb00916292fa5284988a00f98c247a31fe96f49175b99b4f6aa7369c5ab7e57b4f9e474d242499ab3b8
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == 'arm64'
+    - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_386.tar.gz
+      sha512: 4a75f931dd058405e3cde3e93d1174cd11aa7c422fd517e63f04e1dc6121280f16496b2a62f3e25a6ecdfc168ba4d746cd31b2beef7c1714f4addeb8d263efd0
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == '386'
+    - url: https://assets.bonsai.sensu.io/be05ae5a2d16640e97d2374bffed642190f4fff9/sensu-entity-manager_0.3.0_linux_amd64.tar.gz
+      sha512: 3f0d7967489edae1d181424483884c2d2fd4ec382d53a288e796768a0a88642e1136699ad8089e1cce67071acf5d2270f8137ada40abd308fa48ba3537bd8e3a
+      filters:
+        - entity.system.os == 'linux'
+        - entity.system.arch == 'amd64'

--- a/integrations/slack/slack-alerts/README.md
+++ b/integrations/slack/slack-alerts/README.md
@@ -10,8 +10,6 @@ This integration provides the following resources:
 
 * `slack` [pipeline]
 * `slack` [handler]
-* `slack_webhook_url` [secrets]
-* `slack_channel` [secrets]
 * `sensu/sensu-slack-handler` [asset]
 
 ## Dashboards
@@ -28,15 +26,6 @@ There are no known supported dashboards for this integration.
 1. Get a Slack Webhook URL
 
    To obtain a [Slack Webhook URL][slack-webhook-url], please enable Incoming Webhooks for the Slack application Sensu will be using to send alert messages. 
-
-1. Configure Secrets Management 
-
-   This integration requires the following [Sensu Secrets][secrets]: 
-
-   - `slack_webhook_url`
-   - `slack_channel`
-
-   _NOTE: this integration creates one or more Sensu Secrets using the "env" provider. The corresponding environment variables need to be set on every sensu-backend in the Sensu deployment. To add the environment variables, please modify `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` and restart the sensu-backend service(s)._
 
 ## Plugins
 
@@ -68,7 +57,6 @@ This integration does not produce any events that should be processed by an aler
 [annotation]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [plugins]: https://docs.sensu.io/sensu-go/latest/plugins/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/

--- a/integrations/slack/slack-alerts/sensu-integration.yaml
+++ b/integrations/slack/slack-alerts/sensu-integration.yaml
@@ -18,7 +18,7 @@ spec:
     - "@jspaleta"
   prompts:
     - type: section
-      title: Slack Secrets
+      title: Slack Configuration
     - type: markdown
       body: |
         This integration requires a Slack Webhook URL for Slack API Authentication, and a default alerting channel.
@@ -27,68 +27,31 @@ spec:
 
         [Slack Incoming Webhook]: https://api.slack.com/messaging/webhooks
         [Slack Channels]: https://slack.com/help/articles/360017938993-What-is-a-channel
-    - type: section
-      title: Slack Webhook URL
     - type: question
-      name: webhook_url_secret_provider
+      name: slack_webhook_url
+      required: true
       input:
         type: string
-        title: Webhook URL Secret Provider
+        title: Slack Webhook URL
         description: >-
-          Select the Webhook URL secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
+          Slack Webhook URL
     - type: question
-      name: webhook_url_secret_id
+      name: slack_channel
       input:
         type: string
-        title: Secret ID
+        title: Slack Channel
         description: >-
-          Provide the Webhook URL secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_SLACK_WEBHOOK_URL
-    - type: section
-      title: Slack Channel
-    - type: question
-      name: channel_secret_provider
-      input:
-        type: string
-        title: Channel Secret Provider
-        description: >-
-          Select the Channel secret provider where the secrets is stored
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: channel_secret_id
-      input:
-        type: string
-        title: Secret ID
-        description: >-
-          Provide the Channel secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_SLACK_CHANNEL
+          Slack Channel (e.g. "#sensu", "#monitoring", "#ops", or "#alerts")
+        default: "#sensu"
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: slack_webhook_url
+        api_version: core/v2
+        type: Handler
+        name: slack
       patches:
-        - path: /spec/provider
+        - path: /spec/env_vars/0
           op: replace
-          value: "[[webhook_url_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[webhook_url_secret_id]]"
-    - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: slack_channel
-      patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[channel_secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[channel_secret_id]]"
+          value: "SLACK_CHANNEL=[[slack_channel]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "SLACK_WEBHOOK_URL=[[slack_webhook_url]]"

--- a/integrations/slack/slack-alerts/sensu-resources.yaml
+++ b/integrations/slack/slack-alerts/sensu-resources.yaml
@@ -31,33 +31,15 @@ spec:
     --channel ${SLACK_CHANNEL}
     --username SensuGo
     --description-template "{{ .Check.Output }}\n\n[namespace: {{.Entity.Namespace}}]"
+    # NOTE: Requires SLACK_WEBHOOK_URL environment variable or secret
   filters:
     - is_incident
     - not_silenced
   runtime_assets:
     - sensu/sensu-slack-handler:1.4.0
-  secrets:
-    - name: SLACK_WEBHOOK_URL
-      secret: slack_webhook_url
-    - name: SLACK_CHANNEL
-      secret: slack_channel
+  env_vars:
+    - SLACK_CHANNEL="#sensu"
   timeout: 0
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: slack_webhook_url
-spec:
-  provider: env
-  id: SENSU_SLACK_WEBHOOK_URL
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: slack_channel
-spec:
-  provider: env
-  id: SENSU_SLACK_CHANNEL
 ---
 type: Asset
 api_version: core/v2

--- a/integrations/sumologic/sumologic-analytics/README.md
+++ b/integrations/sumologic/sumologic-analytics/README.md
@@ -9,7 +9,6 @@ This integration makes Sensu metrics and events available for searching and anal
 * `sumologic` ([pipeline])
 * `sumologic-metrics` ([sumologic-handler])
 * `sumologic-events` ([handler])
-* `sumologic_http_source_url` ([secret])
 * `sensu/sensu-sumologic-handler:0.3.0` ([asset])
 
 ## Dashboards
@@ -30,10 +29,6 @@ This integration is compatible the the [Sumo Logic App Catalog][sumologic-app-ca
 1. Create a hosted collector & configure an HTTP Logs & Metrics source
 
    [Create a Sumo Logic Hosted Collector][sumologic-hosted-collector] for Sensu Go, and configure an [HTTP Logs and Metrics Source][sumologic-logs-and-metrics-source].
-
-1. Add the Sumo Logic HTTP Logs & Metrics source URL to your secrets provider
-
-   Create an environment variable or Hashicorp Vault secret for the HTTP Logs & Metrics source URL.
 
 ## Plugins
 
@@ -73,8 +68,6 @@ This integration does not produce any events that should be processed by an aler
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
 [sumologic-handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [sensu-plus]: https://sensu.io/features/analytics

--- a/integrations/sumologic/sumologic-analytics/sensu-integration.yaml
+++ b/integrations/sumologic/sumologic-analytics/sensu-integration.yaml
@@ -24,7 +24,7 @@ spec:
     - "@thoward"
   prompts:
     - type: section
-      title: Secrets Management
+      title: Sumo Logic HTTP Logs & Metrics Source
     - type: markdown
       body: |
         This integration requires a Sumo Logic HTTP Logs & Metrics Source URL for integration with Sumo Logic.
@@ -33,31 +33,28 @@ spec:
 
         ["HTTP Logs and Metrics Source"]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source
     - type: question
-      name: secret_provider
+      name: sumologic_url
+      required: true
       input:
         type: string
-        title: Secret Provider
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: secret_id
-      input:
-        type: string
-        title: Secret ID
+        title: Sumo Logic Source URL
         description: >-
-          Provide the Secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: SENSU_SUMOLOGIC_HTTP_SOURCE_URL
+          Sumo Logic HTTP Logs & Metrics Source URL
+        format: url
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: sumologic_http_source_url
+        api_version: pipeline/v1
+        type: SumoLogicMetricsHandler
+        name: sumologic-metrics
       patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[secret_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "SUMOLOGIC_URL=[[sumologic_url]]"
+    - resource:
+        api_version: core/v2
+        type: Handler
+        name: sumologic-events
+      patches:
+        - path: /spec/env_vars/-
+          op: add
+          value: "SUMOLOGIC_URL=[[sumologic_url]]"

--- a/integrations/sumologic/sumologic-analytics/sensu-resources.yaml
+++ b/integrations/sumologic/sumologic-analytics/sensu-resources.yaml
@@ -23,25 +23,15 @@ spec:
       type: Handler
       name: sumologic-events
 ---
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: sumologic_http_source_url
-spec:
-  provider: env
-  id: SENSU_SUMOLOGIC_HTTP_SOURCE_URL
----
 type: SumoLogicMetricsHandler
 api_version: pipeline/v1
 metadata:
   name: sumologic-metrics
 spec:
-  url: "${SUMOLOGIC_HTTP_SOURCE_URL}"
+  url: "${SUMOLOGIC_URL}"
   max_connections: 10
   timeout: 30s
-  secrets:
-    - name: SUMOLOGIC_HTTP_SOURCE_URL
-      secret: sumologic_http_source_url
+  env_vars: []
 ---
 type: Handler
 api_version: core/v2
@@ -55,11 +45,10 @@ spec:
     --source-host "{{ .Entity.Name }}"
     --source-name "{{ .Check.Name }}"
     --source-category "sensu-event"
+    # NOTE: Requires SUMOLOGIC_URL environment varible or secret
   runtime_assets:
-  - sensu/sensu-sumologic-handler:0.3.0
-  secrets:
-  - name: SUMOLOGIC_URL
-    secret: sumologic_http_source_url
+    - sensu/sensu-sumologic-handler:0.3.0
+  env_vars: []
   timeout: 10
 ---
 type: Asset

--- a/integrations/system/network-interface-monitoring/README.md
+++ b/integrations/system/network-interface-monitoring/README.md
@@ -166,8 +166,6 @@ This integration produces the following events which should be processed by an a
 [plugins]: https://docs.sensu.io/sensu-go/latest/plugins/
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [sensu-plus]: https://sensu.io/features/analytics
 [sumo-host-dashboard-link]: https://www.sumologic.com/application/host-and-process-metrics/

--- a/integrations/timescaledb/timescaledb-metrics/README.md
+++ b/integrations/timescaledb/timescaledb-metrics/README.md
@@ -8,7 +8,6 @@ This integration includes the following resources:
 
 * `timescaledb-metrics` [pipeline]
 * `timescaledb-metrics` [handler]
-* `timescaledb_dsn` [secret]
 * `sensu/sensu-timescaledb-handler` [asset]
 
 ## Dashboards
@@ -65,8 +64,6 @@ This integration does not produce any events that should be processed by an aler
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
 [handler]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/
-[secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [sensu-plus]: https://sensu.io/features/analytics

--- a/integrations/timescaledb/timescaledb-metrics/sensu-integration.yaml
+++ b/integrations/timescaledb/timescaledb-metrics/sensu-integration.yaml
@@ -17,38 +17,24 @@ spec:
     - "@sensu"
   prompts:
     - type: section
-      title: Secrets Management
+      title: TimescaleDB Database Connection (DSN)
     - type: markdown
       body: |
         The TimescaleDB Metrics integration requires a [Connection URI] (sometimes referred to as a "Data Source Name", or DSN) for connecting to TimescaleDB.
         
         [Connection URI]: https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6
     - type: question
-      name: secret_provider
+      name: timescaledb_dsn
+      required: true
       input:
         type: string
-        title: Secret Provider
-        enum:
-          - env
-          - vault
-        default: env
-    - type: question
-      name: timescale_db_dsn_id
-      input:
-        type: string
-        title: TimesacleDB DSN Secret ID
-        description: >-
-          Provide the Secret identifier (i.e. environment variable name, or Vault secret key/path)
-        default: example_secret
+        title: TimescaleDB Database Connection URI (e.g. postgresql://username:password@127.0.0.1:5432/database)
   resource_patches:
     - resource:
-        api_version: secrets/v1
-        type: Secret
-        name: timescaledb_dsn
+        api_version: core/v2
+        type: Handler
+        name: timescaledb
       patches:
-        - path: /spec/provider
-          op: replace
-          value: "[[secret_provider]]"
-        - path: /spec/id
-          op: replace
-          value: "[[timescale_db_dsn_id]]"
+        - path: /spec/env_vars/-
+          op: add
+          value: "TIMESCALEDB_DSN=[[timescaledb_dsn]]"

--- a/integrations/timescaledb/timescaledb-metrics/sensu-resources.yaml
+++ b/integrations/timescaledb/timescaledb-metrics/sensu-resources.yaml
@@ -27,20 +27,11 @@ spec:
     sensu-timescaledb-handler
     --table "metrics"
     --sslmode "disable"
+    # NOTE: Requires TIMESCALEDB_DSN environment variable or secret
   timeout: 10
   runtime_assets:
   - sensu/sensu-timescaledb-handler:0.5.0
-  secrets:
-  - name: TIMESCALEDB_DSN
-    secret: timescaledb_dsn
----
-type: Secret
-api_version: secrets/v1
-metadata:
-  name: timescaledb_dsn
-spec:
-  provider: env
-  id: SENSU_TIMESCALEDB_DSN
+  env_vars: []
 ---
 type: Asset
 api_version: core/v2


### PR DESCRIPTION
Without built-in support to write secrets to a secret store, we're temporarily going to avoid using Sensu's built-in Secrets Management features. The secrets management UX might be a little too obtuse for new Sensu users. Instead, we should just ask users for potentially sensitive configuration data (usernames & passwords, etc), and store them as configuration data (e.g. `env_vars`). 

This PR reverts secrets for all existing integrations. 