### PR TITLE
Fix sumologic metrics handler configuration

### DIFF
--- a/integrations/sumologic/sumologic-analytics/sensu-integration.yaml
+++ b/integrations/sumologic/sumologic-analytics/sensu-integration.yaml
@@ -47,9 +47,9 @@ spec:
         type: SumoLogicMetricsHandler
         name: sumologic-metrics
       patches:
-        - path: /spec/env_vars/-
-          op: add
-          value: "SUMOLOGIC_URL=[[sumologic_url]]"
+        - path: /spec/url
+          op: replace
+          value: "[[sumologic_url]]"
     - resource:
         api_version: core/v2
         type: Handler

--- a/integrations/sumologic/sumologic-analytics/sensu-resources.yaml
+++ b/integrations/sumologic/sumologic-analytics/sensu-resources.yaml
@@ -31,7 +31,6 @@ spec:
   url: "${SUMOLOGIC_URL}"
   max_connections: 10
   timeout: 30s
-  env_vars: []
 ---
 type: Handler
 api_version: core/v2


### PR DESCRIPTION
The pipeline/v1.SumoLogicMetricHandler resource doesn't support `env_vars`, so I had broken this integration in https://github.com/sensu/catalog/commit/5c536af7e8fdcc8cd89f78a93cb97e51a9ae3982