### PR TITLE
Update check-disk-usage asset to 0.7.0

### DIFF
--- a/integrations/system/disk-monitoring/sensu-resources.yaml
+++ b/integrations/system/disk-monitoring/sensu-resources.yaml
@@ -40,44 +40,45 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu/check-disk-usage:0.6.0
+  name: sensu/check-disk-usage:0.7.0
+  labels:
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/check-disk-usage
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/check-disk-usage
     io.sensu.bonsai.tier: Supported
-    io.sensu.bonsai.version: 0.6.0
+    io.sensu.bonsai.version: 0.7.0
     io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.name: check-disk-usage
     io.sensu.bonsai.tags: ''
 spec:
   builds:
-    - url: https://assets.bonsai.sensu.io/c06ba5a541026092d685e4d54b76c490801b9919/check-disk-usage_0.6.0_windows_amd64.tar.gz
-      sha512: 0b1df35dc409f7dc8ea849c828036983a5759b6c6ed5940ff1a491b17eb60ca73349dfa9dada73acde0f653a8267c119853771f03b729fd4a95c81e817f9cedb
-      filters:
-        - entity.system.os == 'windows'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/c06ba5a541026092d685e4d54b76c490801b9919/check-disk-usage_0.6.0_darwin_amd64.tar.gz
-      sha512: dcbe19998d1804c8708836c3ec0a7568442ed8f9b33d7d430dc4e1ef59e37f516648b3147344e79c6deb2ad095f588971e37de1f9f9ef1fac558eacc21c184c7
-      filters:
-        - entity.system.os == 'darwin'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/c06ba5a541026092d685e4d54b76c490801b9919/check-disk-usage_0.6.0_linux_armv7.tar.gz
-      sha512: bc382b5b8c9bc70a3be64f4af6686640a852417696357fafcc63faa0f2f7538475cb847444ddcbb3c9486a40725e21a3a2a8c2e3493ff6a0bdfb6d5458ebd683
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'armv7'
-    - url: https://assets.bonsai.sensu.io/c06ba5a541026092d685e4d54b76c490801b9919/check-disk-usage_0.6.0_linux_arm64.tar.gz
-      sha512: 05a0f21ccd93a418eedc596b3b8257a7d34f521e13b8de0d9621c25782829b082391a670e8705f792cd03eddfd36fc965afc6ea3f0f0923202abaebbaabf5467
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'arm64'
-    - url: https://assets.bonsai.sensu.io/c06ba5a541026092d685e4d54b76c490801b9919/check-disk-usage_0.6.0_linux_386.tar.gz
-      sha512: abd19787ac7c81d99058e48ce678e22dee866bae15d587431838f449876fac255f8c1e8c738342225e459b363af5f8b3b22171c9bc858605ea7bebbf143933e4
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == '386'
-    - url: https://assets.bonsai.sensu.io/c06ba5a541026092d685e4d54b76c490801b9919/check-disk-usage_0.6.0_linux_amd64.tar.gz
-      sha512: fa25e317ba8aa3e23d9e3d3c54081ca4529aeba2e7ee437a2bf1ed8cfb3fbf70cd0380eb8cc427a9be17515e437f6346949381cc7ce47f37493e32eb8372ded8
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/2efc9b3e39af1d72266a74bdb4e14cf2c4dc9bd4/check-disk-usage_0.7.0_windows_amd64.tar.gz
+    sha512: e28c0da889d49a55cfff8b027aba3fb65cb3ec41be653b40d84fb734c56b7fd360f9de5d0f9c0321a46b88f3e5b13d9f0ae6bdfd1d2acbee5f9ac09b4514832b
+    filters:
+    - entity.system.os == 'windows'
+    - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/2efc9b3e39af1d72266a74bdb4e14cf2c4dc9bd4/check-disk-usage_0.7.0_darwin_amd64.tar.gz
+    sha512: 2b3a8f139cf38b9b504556fb4b97fcf95f34524b93e6cef8d0698c100a54d05581322bfbbd6670921e277d20b12e41d7757abf6189b6a0b4188c46e5420f354f
+    filters:
+    - entity.system.os == 'darwin'
+    - entity.system.arch == 'amd64'
+  - url: https://assets.bonsai.sensu.io/2efc9b3e39af1d72266a74bdb4e14cf2c4dc9bd4/check-disk-usage_0.7.0_linux_armv7.tar.gz
+    sha512: 0c2c5ce8949cb80c778412a08c1b9e10086de413ac06807708cf975864eb1a1c9fa3d798d6e028f19867c7d478f0df4d9c7b94a42761ecf2ab60a3d839a0a607
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'armv7'
+  - url: https://assets.bonsai.sensu.io/2efc9b3e39af1d72266a74bdb4e14cf2c4dc9bd4/check-disk-usage_0.7.0_linux_arm64.tar.gz
+    sha512: f5234e9f422dbaf0e5c463e4fe01c52fa5c7229b395a33d1a3ba77d3accd780445ddad42661a522e0ad04ca502928460a8cfaf24e6fe4efa74514a8ad8e0ffd8
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm64'
+  - url: https://assets.bonsai.sensu.io/2efc9b3e39af1d72266a74bdb4e14cf2c4dc9bd4/check-disk-usage_0.7.0_linux_386.tar.gz
+    sha512: 102f2ca1ec7811bd3d42fa3ff1731dfcf8674cfd6b9d0025f992e27cdcd72de2c6f34c8de00653d163be4b4021a684dc94bb5f3b61489c00f5cee47e8353ef1a
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == '386'
+  - url: https://assets.bonsai.sensu.io/2efc9b3e39af1d72266a74bdb4e14cf2c4dc9bd4/check-disk-usage_0.7.0_linux_amd64.tar.gz
+    sha512: 0b76e7718bcaf8843d6ece48def228a6bbbe4221442b995d66ef17b52820f82640feebceee1003f400cd35535f33a31fb4d2a98c0012aa334f4e8c4ce726f57a
+    filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'

--- a/integrations/system/disk-monitoring/sensu-resources.yaml
+++ b/integrations/system/disk-monitoring/sensu-resources.yaml
@@ -14,7 +14,7 @@ spec:
     --warning {{ .annotations.disk_usage_warning_threshold | default "80.0" }}
     --critical {{ .annotations.disk_usage_critical_threshold | default "90.0" }}
   runtime_assets:
-    - sensu/check-disk-usage:0.6.0
+    - sensu/check-disk-usage:0.7.0
   publish: true
   subscriptions:
     - system


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Timestamp precision has been fixed in the 0.7.0 release of the check-disk-usage asset which is required for metrics output to function correctly.