### PR TITLE
Use new secrets fallback workflow for sensitive Elasticsearch configuration parameters

### DIFF
--- a/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
+++ b/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
@@ -35,7 +35,8 @@ spec:
         type: string
         title: Elasticsearch URL
         description: >-
-          Provide the Elasticsearch URL (e.g. http://elasticsearch:9200); supports HTTP and HTTPS.
+          Provide the Elasticsearch URL (e.g. http://elasticsearch.mycompany.com:9200); supports HTTP and HTTPS.
+        default: http://elasticsearch.mycompany.com:9200
     - type: question
       name: elasticsearch_index
       required: true
@@ -47,12 +48,14 @@ spec:
           NOTE: this can be configured / overriden on a per-host basis.
         default: sensu_events
     - type: section
-      title: Elasticsearch Username
+      title: Elasticsearch Username & Password
     - type: markdown
       body: |
-        Please provide an Elastisearch username _OR_ select a [Sensu Secret].
+        This integration requires an Elasticsearch username & password for authentication.
 
-        [Sensu Secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
+        Please select [Sensu Secrets] or provide an Elasticsearch username and password.
+
+        [Sensu Secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
     - type: question
       name: elasticsearch_username
       required: true
@@ -66,7 +69,7 @@ spec:
             properties:
               option:
                 type: string
-                title: Environment Variable or Secrets Management?
+                title: Elasticsearch Username
                 const: secret
                 constLocale:
                   title: Secret
@@ -85,7 +88,7 @@ spec:
             properties:
               option:
                 type: string
-                title: Environment Variable or Secrets Management?
+                title: Elasticsearch Username
                 const: env_var
                 constLocale:
                   title: Environment Variable
@@ -96,13 +99,6 @@ spec:
                 title: Elasticsearch Username
                 description: >-
                   Provide the Elasticsearch username (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
-    - type: section
-      title: Elasticsearch Password
-    - type: markdown
-      body: |
-        Please provide the Elastisearch password _OR_ select a [Sensu Secret].
-
-        [Sensu Secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
     - type: question
       name: elasticsearch_password
       required: true
@@ -116,7 +112,7 @@ spec:
             properties:
               option:
                 type: string
-                title: Environment Variable or Secrets Management?
+                title: Elasticsearch Password
                 const: secret
                 constLocale:
                   title: Secret
@@ -135,7 +131,7 @@ spec:
             properties:
               option:
                 type: string
-                title: Environment Variable or Secrets Management?
+                title: Elasticsearch Password
                 const: env_var
                 constLocale:
                   title: Environment Variable

--- a/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
+++ b/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
@@ -50,52 +50,90 @@ spec:
       title: Elasticsearch Username
     - type: markdown
       body: |
-        Please provide an Elastisearch username _OR_ configure a [Sensu Secret].
-
-        NOTE: if both an environment variable _and_ secret are set, the secret will be used.
+        Please provide an Elastisearch username _OR_ select a [Sensu Secret].
 
         [Sensu Secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
     - type: question
       name: elasticsearch_username
+      required: true
       input:
-        type: string
-        title: Elasticsearch Username (environment variable)
-        description: >-
-          Provide the Elasticsearch username (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
-    - type: question
-      name: elasticsearch_username_secret
-      input:
-        type: string
-        title: Elasticsearch Username (Sensu Secret)
-        description: >-
-          Select the Elasticsearch username Sensu Secret
-        ref: secrets/v1/secret/metadata/name
-        refFilter: .name matches 'elasticsearch'
+        type: object
+        oneOf:
+          - type: object
+            properties:
+              option:
+                type: string
+                title: Environment Variable or Secrets Management?
+                const: env_var
+                constLocale:
+                  title: Environment Variable
+                  description: >-
+                    Select this option to store sensitive configuration as environment variables
+              env_var:
+                type: string
+                title: Elasticsearch Username
+                description: >-
+                  Provide the Elasticsearch username (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+          - type: object
+            properties:
+              option:
+                type: string
+                title: Environment Variable or Secrets Management?
+                const: secret
+                constLocale:
+                  title: Secret
+                  description: >-
+                    Select this option to use Sensu Secrets Management
+              secret:
+                type: string
+                title: Elasticsearch Username (Sensu Secret)
+                description: >-
+                  Select the Elasticsearch username (Sensu Secret)
+                ref: secrets/v1/secret/metadata/name
     - type: section
       title: Elasticsearch Password
     - type: markdown
       body: |
-        Please provide an Elastisearch password _OR_ select a [Sensu Secret].
-
-        NOTE: if both an environment variable _and_ secret are set, the secret will be used.
+        Please provide the Elastisearch password _OR_ select a [Sensu Secret].
 
         [Sensu Secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
     - type: question
       name: elasticsearch_password
+      required: true
       input:
-        type: string
-        title: Elasticsearch Password
-        description: >-
-          Provide the Elasticsearch password (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
-    - type: question
-      name: elasticsearch_password_secret
-      input:
-        type: string
-        title: Elasticsearch Password (Sensu Secret)
-        description: >-
-          Select the Elasticsearch password Sensu Secret
-        ref: secrets/v1/secret/metadata/name
-        refFilter: .name matches 'elasticsearch'
+        type: object
+        oneOf:
+          - type: object
+            properties:
+              option:
+                type: string
+                title: Environment Variable or Secrets Management?
+                const: env_var
+                constLocale:
+                  title: Environment Variable
+                  description: >-
+                    Select this option to store sensitive configuration as environment variables
+              env_var:
+                type: string
+                title: Elasticsearch Password
+                description: >-
+                  Provide the Elasticsearch password (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+          - type: object
+            properties:
+              option:
+                type: string
+                title: Environment Variable or Secrets Management?
+                const: secret
+                constLocale:
+                  title: Secret
+                  description: >-
+                    Select this option to use Sensu Secrets Management
+              secret:
+                type: string
+                title: Elasticsearch Password (Sensu Secret)
+                description: >-
+                  Select the Elasticsearch password (Sensu Secret)
+                ref: secrets/v1/secret/metadata/name
   resource_patches:
     - resource:
         api_version: core/v2
@@ -110,19 +148,19 @@ spec:
           value: "ELASTICSEARCH_INDEX=[[elasticsearch_index]]"
         - path: /spec/env_vars/-
           op: add
-          value: "ELASTICSEARCH_USERNAME=[[elasticsearch_username]]"
+          value: "ELASTICSEARCH_USERNAME=[[elasticsearch_username.env_var]]"
         - path: /spec/env_vars/-
           op: add
-          value: "ELASTICSEARCH_PASSWORD=[[elasticsearch_password]]"
+          value: "ELASTICSEARCH_PASSWORD=[[elasticsearch_password.env_var]]"
         - path: /spec/secrets/-
           op: add
           value:
-            secret: "[[elasticsearch_username_secret]]"
+            secret: "[[elasticsearch_username.secret]]"
             name: ELASTICSEARCH_USERNAME
         - path: /spec/secrets/-
           op: add
           value:
-            secret: "[[elasticsearch_password_secret]]"
+            secret: "[[elasticsearch_password.secret]]"
             name: ELASTICSEARCH_PASSWORD
   post_install:
     - type: section

--- a/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
+++ b/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
@@ -64,21 +64,6 @@ spec:
               option:
                 type: string
                 title: Environment Variable or Secrets Management?
-                const: env_var
-                constLocale:
-                  title: Environment Variable
-                  description: >-
-                    Select this option to store sensitive configuration as environment variables
-              env_var:
-                type: string
-                title: Elasticsearch Username
-                description: >-
-                  Provide the Elasticsearch username (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
-          - type: object
-            properties:
-              option:
-                type: string
-                title: Environment Variable or Secrets Management?
                 const: secret
                 constLocale:
                   title: Secret
@@ -90,6 +75,21 @@ spec:
                 description: >-
                   Select the Elasticsearch username (Sensu Secret)
                 ref: secrets/v1/secret/metadata/name
+          - type: object
+            properties:
+              option:
+                type: string
+                title: Environment Variable or Secrets Management?
+                const: env_var
+                constLocale:
+                  title: Environment Variable
+                  description: >-
+                    Select this option to store sensitive configuration as environment variables
+              env_var:
+                type: string
+                title: Elasticsearch Username
+                description: >-
+                  Provide the Elasticsearch username (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
     - type: section
       title: Elasticsearch Password
     - type: markdown
@@ -108,21 +108,6 @@ spec:
               option:
                 type: string
                 title: Environment Variable or Secrets Management?
-                const: env_var
-                constLocale:
-                  title: Environment Variable
-                  description: >-
-                    Select this option to store sensitive configuration as environment variables
-              env_var:
-                type: string
-                title: Elasticsearch Password
-                description: >-
-                  Provide the Elasticsearch password (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
-          - type: object
-            properties:
-              option:
-                type: string
-                title: Environment Variable or Secrets Management?
                 const: secret
                 constLocale:
                   title: Secret
@@ -134,6 +119,21 @@ spec:
                 description: >-
                   Select the Elasticsearch password (Sensu Secret)
                 ref: secrets/v1/secret/metadata/name
+          - type: object
+            properties:
+              option:
+                type: string
+                title: Environment Variable or Secrets Management?
+                const: env_var
+                constLocale:
+                  title: Environment Variable
+                  description: >-
+                    Select this option to store sensitive configuration as environment variables
+              env_var:
+                type: string
+                title: Elasticsearch Password
+                description: >-
+                  Provide the Elasticsearch password (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
   resource_patches:
     - resource:
         api_version: core/v2

--- a/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
+++ b/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml
@@ -60,6 +60,9 @@ spec:
         type: object
         oneOf:
           - type: object
+            required:
+              - option
+              - secret
             properties:
               option:
                 type: string
@@ -76,6 +79,9 @@ spec:
                   Select the Elasticsearch username (Sensu Secret)
                 ref: secrets/v1/secret/metadata/name
           - type: object
+            required:
+              - option
+              - env_var
             properties:
               option:
                 type: string
@@ -104,6 +110,9 @@ spec:
         type: object
         oneOf:
           - type: object
+            required:
+              - option
+              - secret
             properties:
               option:
                 type: string
@@ -120,6 +129,9 @@ spec:
                   Select the Elasticsearch password (Sensu Secret)
                 ref: secrets/v1/secret/metadata/name
           - type: object
+            required:
+              - option
+              - env_var
             properties:
               option:
                 type: string

--- a/integrations/elasticsearch/elasticsearch-events/sensu-resources.yaml
+++ b/integrations/elasticsearch/elasticsearch-events/sensu-resources.yaml
@@ -17,7 +17,7 @@ spec:
         type: Handler
         name: elasticsearch-events
 ---
-# NOTE: requires ELASTICSEARCH_URL, ELASTICSEARCH_INDEX, ELASTICSEARCH_USERNAME, and ELASTICSEARCH_PASSWORD environment variable(s) or secret
+# NOTE: requires ELASTICSEARCH_URL, ELASTICSEARCH_INDEX, ELASTICSEARCH_USERNAME, and ELASTICSEARCH_PASSWORD environment variable(s) or secret(s)
 type: Handler
 api_version: core/v2
 metadata:


### PR DESCRIPTION
Depends on sensu/sensu-enterprise-go#2155 (see resource patch references to [`elasticsearch_username.secret`, `elasticsearch_username.env_var`, `elasticsearch_password.secret`, `elasticsearch_password.env_var`](https://github.com/sensu/catalog/blob/ch/secrets-fallback/integrations/elasticsearch/elasticsearch-events/sensu-integration.yaml#L161-L176)). 