### PR TITLE
Clean up the integration templates

### DIFF
--- a/templates/check-template/sensu-integration.yaml
+++ b/templates/check-template/sensu-integration.yaml
@@ -19,6 +19,21 @@ spec:
     - "@sensu"
   prompts:
     - type: section
+      title: Configure Sensu Subscriptions
+    - type: markdown
+      body: |
+        Configure which Sensu Agent subscriptions this check should be run on.
+    - type: question
+      name: subscriptions
+      input:
+        type: array
+        items:
+          type: string
+          title: Sensu Subscriptions
+          ref: core/v2/entity/subscriptions
+        default:
+          - example
+    - type: section
       title: Pipeline Configuration
     - type: markdown
       body: |
@@ -56,26 +71,29 @@ spec:
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "metrics"
   resource_patches:
-    resource:
-      api_version: core/v2
-      type: CheckConfig
-      name: example
-    patches:
-      - path: /spec/pipelines/-
-        op: add
-        value:
-          api_version: core/v2
-          type: Pipeline
-          name: "[[alert_pipeline]]"
-      - path: /spec/pipelines/-
-        op: add
-        value:
-          api_version: core/v2
-          type: Pipeline
-          name: "[[incident_pipeline]]"
-      - path: /spec/pipelines/-
-        op: add
-        value:
-          api_version: core/v2
-          type: Pipeline
-          name: "[[metrics_pipeline]]"
+    - resource:
+        api_version: core/v2
+        type: CheckConfig
+        name: {{integration_name}}
+      patches:
+        - op: replace
+          path: /spec/subscriptions
+          value: subscriptions
+        - op: add
+          path: /spec/pipelines/-
+          value:
+            api_version: core/v2
+            type: Pipeline
+            name: "[[alert_pipeline]]"
+        - op: add
+          path: /spec/pipelines/-
+          value:
+            api_version: core/v2
+            type: Pipeline
+            name: "[[incident_pipeline]]"
+        - op: add
+          path: /spec/pipelines/-
+          value:
+            api_version: core/v2
+            type: Pipeline
+            name: "[[metrics_pipeline]]"

--- a/templates/check-template/sensu-resources.yaml
+++ b/templates/check-template/sensu-resources.yaml
@@ -1,0 +1,20 @@
+---
+# Requires XX and YY secret(s) or environment variable(s).
+api_version: core/v2
+type: CheckConfig
+metadata:
+  name: helloworld
+  labels: {}
+  annotations: {}
+spec:
+  command: ""
+  runtime_assets: []
+  env_vars: []
+  secrets: []
+  publish: true
+  subscriptions: []
+  interval: 30
+  timeout: 10
+  output_metric_format: prometheus_text
+  output_metric_tags: []
+  pipelines: []


### PR DESCRIPTION
This PR is the start of a final pass review of the monitoring/pipeline integration templates so they reflect the v1 patterns we adopted for the 6.7.0 launch. 