### PR TITLE
Update AWS ALB integration

### DIFF
--- a/integrations/aws/aws-alb-monitoring/sensu-integration.yaml
+++ b/integrations/aws/aws-alb-monitoring/sensu-integration.yaml
@@ -280,7 +280,7 @@ spec:
       patches:
         - op: replace
           path: /metadata/name
-          value: "[[aws_region]]-aws-alb-metrics"
+          value: "aws-[[aws_region]]-alb-metrics"
         - op: add
           path: /spec/env_vars/-
           value: "AWS_REGION=[[aws_region]]"
@@ -297,7 +297,7 @@ spec:
           value: "aws/[[aws_region]]"
         - op: replace
           path: /spec/proxy_entity_name
-          value: "[[aws_region]]-aws-alb"
+          value: "aws.[[aws_region]]"
         - op: replace
           path: /spec/output_metric_thresholds/0/thresholds/0/min
           value: "[[minimum_healthy_host_count]]"

--- a/integrations/aws/aws-alb-monitoring/sensu-resources.yaml
+++ b/integrations/aws/aws-alb-monitoring/sensu-resources.yaml
@@ -2,7 +2,8 @@
 # Requires AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY secret(s) or environment variable(s).
 #
 # NOTE: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secret(s) or environment variable(s) are not needed if
-# run from an EC2 instance with an IAM instance profile that has the arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess rule.
+# run from an EC2 instance with an IAM instance profile that has read-only access to the appropriate
+# CloudWatch metrics (e.g. arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess).
 api_version: core/v2
 type: CheckConfig
 metadata:


### PR DESCRIPTION
* Updated check naming convention to be `aws-[[aws_region]]-alb-metrics`
* Updated the proxy entity name to be `aws.[[aws_region]]`
* Updated comment RE: auth requirements