### PR TITLE
Fix bad deffault in exclude token substitution template

### DIFF
--- a/integrations/system/network-interface-monitoring/sensu-resources.yaml
+++ b/integrations/system/network-interface-monitoring/sensu-resources.yaml
@@ -8,7 +8,7 @@ spec:
   command: >-
     network-interface-checks
     --state-file {{ .annotations.network_interface_monitoring_state_file | default "/var/cache/sensu/sensu-agent/network-interface-checks" }}
-    --exclude-interfaces {{ .annotations.excluded_network_interfaces | default "" }}
+    --exclude-interfaces {{ .annotations.excluded_network_interfaces | default "\"\"" }}
   runtime_assets:
     - sensu/network-interface-checks:0.2.0
   env_vars: []


### PR DESCRIPTION
make sure default exclude interface option populates the cmdline flag value to avoid an error

Without this fix the command could run in a such a way that the exclude flag is given no value, which results in an error.
What you want to do is have the exclude flag populate with an empty string from the shell cmdline pov.