### PR TITLE
Add PR merge workflow that will create need-tag issues

### DIFF
--- a/.github/workflows/sensu-catalog-propose-tag.yml
+++ b/.github/workflows/sensu-catalog-propose-tag.yml
@@ -1,0 +1,62 @@
+---
+name: 'Sensu Catalog Propose Tag'
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  propose-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Fetch Tags
+        run: git fetch --tags
+      - name: Propose tag after PR merge    
+        shell: 
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true 
+        run: |
+          if [  -z ${GITHUB_SHA} ]; then
+            echo -e "GITHUB_SHA empty, taking no additional action" >&2
+            exit 0
+          fi
+          echo ${GITHUB_REPOSITORY}
+          echo ${GITHUB_TOKEN}
+          commit_epoch=$(git show -s --format=%ct ${GITHUB_SHA})
+          d=`date --utc -d @$commit_epoch +%Y%m%d`
+          integrations=$(git log -m -1 --name-only $1  | grep "integrations/" | xargs -n 1 dirname  | sed -e 's/^integrations\///' |sort -u)
+
+          for integration in $integrations
+          do
+            trimmed=$(echo ${integration} | sed 's:/*$::')
+            base_version=${trimmed}/${d}
+            major=0
+            minor=0
+            invalid=1
+            while [ "$minor" -le 10 -a "$invalid" -eq 1 ]
+            do
+              version=$base_version.$major.$minor
+              if [ $(git tag -l "$version") ]; then
+                invalid=1
+              else
+                invalid=0
+              fi
+              ((minor=i+1))
+            done
+            echo $version
+            if [  -z ${GITHUB_TOKEN} ]; then
+              echo -e "GITHUB_TOKEN empty, skipping issue creation" >&2
+            else
+              curl \
+                -X POST \
+                -H "Authorization: token ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${GITHUB_REPOSITORY}/issues \
+                -d "{\"title\":\"Proposed Release Tag ${version}\",\"body\":\"Automatic tag proposal based on files changed in PR merge.\n  Commit: ${GITHUB_SHA}\n  REF: ${GITHUB_REF}\n  Integration: ${trimmed}\",\"labels\":[\"need-tag\"]}"
+            fi
+          done
+


### PR DESCRIPTION
This github action _should_ examine a merged PR commit and suggest integration release tags to generate in the form of a new issue using label "needs-tag".

The purpose of this automation is to ensure people with release tagging authority don't miss a needed integration release after a  PR merge is done.

This automation should be able to handle nominal single integration PRs as well as cross integration PRs (such as documentation refactors)