### PR TITLE
Remove doc references to unsupported redirect flag

### DIFF
--- a/integrations/caddy/caddy-monitoring/README.md
+++ b/integrations/caddy/caddy-monitoring/README.md
@@ -27,22 +27,7 @@ There are no compatible dashboards for this integration.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:2019/metrics"
-   ```
-
-2. **[OPTIONAL] Configure custom request headers**
+1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
 

--- a/integrations/cockroachdb/cockroachdb-monitoring/README.md
+++ b/integrations/cockroachdb/cockroachdb-monitoring/README.md
@@ -26,22 +26,7 @@ There are no compatible dashboards for this integration.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:8080/_status/vars"
-   ```
-
-2. **[OPTIONAL] Configure custom request headers**
+1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
 

--- a/integrations/docker/docker-monitoring/README.md
+++ b/integrations/docker/docker-monitoring/README.md
@@ -39,21 +39,6 @@ Coming soon!
 
    For more details on setting this up read the ["Configure Docker" section of the article "Collect Docker Metrics with Prometheus"](https://docs.docker.com/config/daemon/prometheus/#configure-docker). Note that you do not need to run Prometheus to use this endpoint, so only that one paragraph is relevant from that article.
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:9323/metrics"
-   ```
-
 1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.

--- a/integrations/etcd/etcd-monitoring/README.md
+++ b/integrations/etcd/etcd-monitoring/README.md
@@ -26,22 +26,7 @@ There are no compatible dashboards for this integration.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:2379/metrics"
-   ```
-
-2. **[OPTIONAL] Configure custom request headers**
+1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
 

--- a/integrations/neo4j/neo4j-monitoring/README.md
+++ b/integrations/neo4j/neo4j-monitoring/README.md
@@ -41,21 +41,6 @@ There are no compatible dashboards for this integration.
 
    For more information read the [Neo4j Metrics documentation](https://neo4j.com/docs/operations-manual/current/monitoring/metrics/expose/#metrics-prometheus).
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:2004/metrics"
-   ```
-
 1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.

--- a/integrations/prometheus/node-exporter-metrics/README.md
+++ b/integrations/prometheus/node-exporter-metrics/README.md
@@ -28,22 +28,7 @@ There are no compatible dashboards for this integration.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:9100/"
-   ```
-
-2. **[OPTIONAL] Configure custom request headers**
+1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
 

--- a/integrations/prometheus/windows-exporter-metrics/README.md
+++ b/integrations/prometheus/windows-exporter-metrics/README.md
@@ -28,22 +28,7 @@ There are no compatible dashboards for this integration.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:9182/"
-   ```
-
-2. **[OPTIONAL] Configure custom request headers**
+1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
 

--- a/integrations/rabbitmq/rabbitmq-monitoring/README.md
+++ b/integrations/rabbitmq/rabbitmq-monitoring/README.md
@@ -28,22 +28,7 @@ There are no compatible dashboards for this integration.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
-
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
-
-   Example:
-
-   ```yaml
-   spec:
-     command: >-
-       http-get
-       --timeout 10
-       --redirect-ok
-       --url "http://127.0.0.1:15692/"
-   ```
-
-2. **[OPTIONAL] Configure custom request headers**
+1. **[OPTIONAL] Configure custom request headers**
 
    To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
 


### PR DESCRIPTION
Accidentally included a reference to `--redirect-ok` command line flag in the doc/examples for catalog integrations using the `http-get` check. Removed those.