### PR TITLE
update to latest servicenow bonsai asset 3.0.2

### DIFF
--- a/integrations/servicenow/servicenow-cmdb-registration/sensu-resources.yaml
+++ b/integrations/servicenow/servicenow-cmdb-registration/sensu-resources.yaml
@@ -55,45 +55,45 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu/sensu-servicenow-handler:3.0.0
-  labels:
+  name: sensu/sensu-servicenow-handler:3.0.2
+  labels: 
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-servicenow-handler
     io.sensu.bonsai.tier: Community
-    io.sensu.bonsai.version: 3.0.0
+    io.sensu.bonsai.version: 3.0.2
     io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.name: sensu-servicenow-handler
     io.sensu.bonsai.tags: ''
 spec:
   builds:
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_windows_amd64.tar.gz
-    sha512: d68e7e3c5a520da6c8787335410878f11191761cbd24022d9d1f7c7e2449a7d1f80789ee3e05704e997941c935dc723ecc67102a08d8ab88dfbbd504d2d395bc
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_windows_amd64.tar.gz
+    sha512: 561573f283e92bbb4fbf7455d8d68710ac4e4593ce3aab03ea18dbff362a413d3efd92118f9ef3e27e516bdefe7b27e1915dade739c686db91d8de537a98d2bc
     filters:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_darwin_amd64.tar.gz
-    sha512: 6439cfc1d1a2c2235774165b640602a9f6368850e689084fb7140bedcc463f9692f35ab7e1f53476c2245acda2332205d6d8883c0b68b8bb1848be3d4e8634ba
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_darwin_amd64.tar.gz
+    sha512: bd7f7f9b974bfda1ae862e07355379ad19e92ceea18896805a2a97995ed9af725840f226addbecdf5d1184c12e7820b3c44579b1eec2e71f61e98d3c07916451
     filters:
     - entity.system.os == 'darwin'
     - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_armv7.tar.gz
-    sha512: 5ce11d99a55996fbed02ead32b5ae0756329a26836ea2c22d40c1eeceea31a9afae04716c8fc2906ff7619406f0b2f9daf37e5436a140961e6c85839e669c12b
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_armv7.tar.gz
+    sha512: 48e63c4b54e87b7a6e8a6826a9b051f05d17165938b19a12cc420fa3bff8df54cdd9ed1906fce157f53cee9ef816872f976674f21753cd578243fdd12f729c07
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'armv7'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_arm64.tar.gz
-    sha512: 23e115dbb6545e9f049e284ad48cc7d39ab5ba78411604949cb9b2093061cd5a3832026e03dcf8659a6671410f8b829c2a41fc0bbea96bcf8a1cd4c80cd44412
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_arm64.tar.gz
+    sha512: af6d131909546b208efd1834fd202406eb728d1a96799cf1ff4da0517a644fdb7d12b664f9012ae70fd5330094c026df3698440f1805c5bd15219441129c2048
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'arm64'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_386.tar.gz
-    sha512: 9136b56573e741777591e6248ba7536b4be4d7fd707cadd0094ecb0db98fef0e30dfaeab53422f72cdb21cc5788df28d982930bed70adabded53c5bc88180864
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_386.tar.gz
+    sha512: 16a233bc337b34406b708f75a883de397f2b26320f0e08c4142f3e80ce86c0a6bdfd09c7ae84c4cf1091860b9aa2ebfa19b1b73b440d95bfe78548fcf2ed4087
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == '386'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_amd64.tar.gz
-    sha512: 5f2312292888e271e65139cb7516db7d6dac72fc010b1c97f5f9efce87c1462742228e88178ab3957dc35653cde58d74493d37cd40f576e7eac57685ab23d8e5
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_amd64.tar.gz
+    sha512: 84c4f5fe518c97a01beeb477e73d5a52c78ae306f3bb865f7ca58af5a538dc71071215fd5d19b78d3144c300192366a5030344bc71e571c46b3a7ba2fb030008
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'

--- a/integrations/servicenow/servicenow-cmdb-registration/sensu-resources.yaml
+++ b/integrations/servicenow/servicenow-cmdb-registration/sensu-resources.yaml
@@ -34,7 +34,7 @@ spec:
     --cmdb-registration
     --cmdb-properties asset_tag
   runtime_assets:
-    - sensu/sensu-servicenow-handler:3.0.0
+    - sensu/sensu-servicenow-handler:3.0.2
   env_vars: []
   secrets: []
   timeout: 10

--- a/integrations/servicenow/servicenow-incident-management/sensu-resources.yaml
+++ b/integrations/servicenow/servicenow-incident-management/sensu-resources.yaml
@@ -36,7 +36,7 @@ spec:
     --incident-work-notes "{{ .Check.Output }}"
     --incident-properties category
   runtime_assets:
-    - sensu/sensu-servicenow-handler:3.0.0
+    - sensu/sensu-servicenow-handler:3.0.2
   env_vars: []
   secrets: []
   timeout: 10

--- a/integrations/servicenow/servicenow-incident-management/sensu-resources.yaml
+++ b/integrations/servicenow/servicenow-incident-management/sensu-resources.yaml
@@ -56,45 +56,45 @@ spec:
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu/sensu-servicenow-handler:3.0.0
-  labels:
+  name: sensu/sensu-servicenow-handler:3.0.2
+  labels: 
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-servicenow-handler
     io.sensu.bonsai.tier: Community
-    io.sensu.bonsai.version: 3.0.0
+    io.sensu.bonsai.version: 3.0.2
     io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.name: sensu-servicenow-handler
     io.sensu.bonsai.tags: ''
 spec:
   builds:
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_windows_amd64.tar.gz
-    sha512: d68e7e3c5a520da6c8787335410878f11191761cbd24022d9d1f7c7e2449a7d1f80789ee3e05704e997941c935dc723ecc67102a08d8ab88dfbbd504d2d395bc
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_windows_amd64.tar.gz
+    sha512: 561573f283e92bbb4fbf7455d8d68710ac4e4593ce3aab03ea18dbff362a413d3efd92118f9ef3e27e516bdefe7b27e1915dade739c686db91d8de537a98d2bc
     filters:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_darwin_amd64.tar.gz
-    sha512: 6439cfc1d1a2c2235774165b640602a9f6368850e689084fb7140bedcc463f9692f35ab7e1f53476c2245acda2332205d6d8883c0b68b8bb1848be3d4e8634ba
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_darwin_amd64.tar.gz
+    sha512: bd7f7f9b974bfda1ae862e07355379ad19e92ceea18896805a2a97995ed9af725840f226addbecdf5d1184c12e7820b3c44579b1eec2e71f61e98d3c07916451
     filters:
     - entity.system.os == 'darwin'
     - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_armv7.tar.gz
-    sha512: 5ce11d99a55996fbed02ead32b5ae0756329a26836ea2c22d40c1eeceea31a9afae04716c8fc2906ff7619406f0b2f9daf37e5436a140961e6c85839e669c12b
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_armv7.tar.gz
+    sha512: 48e63c4b54e87b7a6e8a6826a9b051f05d17165938b19a12cc420fa3bff8df54cdd9ed1906fce157f53cee9ef816872f976674f21753cd578243fdd12f729c07
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'armv7'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_arm64.tar.gz
-    sha512: 23e115dbb6545e9f049e284ad48cc7d39ab5ba78411604949cb9b2093061cd5a3832026e03dcf8659a6671410f8b829c2a41fc0bbea96bcf8a1cd4c80cd44412
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_arm64.tar.gz
+    sha512: af6d131909546b208efd1834fd202406eb728d1a96799cf1ff4da0517a644fdb7d12b664f9012ae70fd5330094c026df3698440f1805c5bd15219441129c2048
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'arm64'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_386.tar.gz
-    sha512: 9136b56573e741777591e6248ba7536b4be4d7fd707cadd0094ecb0db98fef0e30dfaeab53422f72cdb21cc5788df28d982930bed70adabded53c5bc88180864
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_386.tar.gz
+    sha512: 16a233bc337b34406b708f75a883de397f2b26320f0e08c4142f3e80ce86c0a6bdfd09c7ae84c4cf1091860b9aa2ebfa19b1b73b440d95bfe78548fcf2ed4087
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == '386'
-  - url: https://assets.bonsai.sensu.io/d01fd3bcf368d5511c9754d345ebc3b0b05f911d/sensu-servicenow-handler_3.0.0_linux_amd64.tar.gz
-    sha512: 5f2312292888e271e65139cb7516db7d6dac72fc010b1c97f5f9efce87c1462742228e88178ab3957dc35653cde58d74493d37cd40f576e7eac57685ab23d8e5
+  - url: https://assets.bonsai.sensu.io/4d2872648afce6f00a4822c07ab44e3eae5e947c/sensu-servicenow-handler_3.0.2_linux_amd64.tar.gz
+    sha512: 84c4f5fe518c97a01beeb477e73d5a52c78ae306f3bb865f7ca58af5a538dc71071215fd5d19b78d3144c300192366a5030344bc71e571c46b3a7ba2fb030008
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'


### PR DESCRIPTION
Update to latest servicenow plugin asset patch release 3.0.2

this change has not be tested against a live full servicenow service account.
But because this is a patch release update, no functionality has materially changed.

Should be tested against a live account as part of review if possible.