### PR TITLE
Text updates: aws/aws-lambda-monitoring

### DIFF
--- a/integrations/aws/aws-lambda-monitoring/CHANGELOG.md
+++ b/integrations/aws/aws-lambda-monitoring/CHANGELOG.md
@@ -7,7 +7,14 @@ to [Semantic Versioning][semver].
 
 ## Unreleased
 
-- *n/a*
+- Revise text labels and prompts in configuration modal
+- Remove "none" option for providing credentials for consistency among integrations
+- Add summary for success screen in integration yaml file
+- Add several setup steps and options in README
+- Update README link references to match headings on the linked pages
+- Add alert for aws_lambda_dead_letter_errors in README
+- Reformat metrics table in README
+- Add reference documentation list
 
 ## [0.1.0] - {{current_date}}
 

--- a/integrations/aws/aws-lambda-monitoring/README.md
+++ b/integrations/aws/aws-lambda-monitoring/README.md
@@ -2,16 +2,13 @@
 
 <!-- Sensu Integration description; supports markdown -->
 
-The [AWS Lambda] monitoring integration collects Lambda metrics from [AWS CloudWatch], and alerts on various Lamda conditions.
-
-[AWS Lambda]: https://aws.amazon.com/lambda/
-[AWS CloudWatch]: https://aws.amazon.com/cloudwatch/
+The AWS Lambda Monitoring integration collects [AWS Lambda] metrics from [AWS CloudWatch] and sends alerts for various Lamda conditions.
 
 <!-- Provide a high level overview of the integration contents (e.g. checks, filters, mutators, handlers, assets, etc) -->
 
-This integration includes the following resources:
+This integration includes the following Sensu resources:
 
-* `aws-lambda-metrics` [check]
+* `aws-{AWS_PROFILE}-lambda-metrics` [check]
 * `sensu/sensu-cloudwatch-check:0.2.0` [asset]
 
 ## Dashboards
@@ -22,96 +19,114 @@ This integration includes the following resources:
 
 <!-- ![](img/dashboard.png) -->
 
-There are no compatible dashboards for this integration.
+The AWS Lambda Monitoring integration does not have compatible dashboards.
 
 ## Setup
 
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. This integration requires access to AWS CloudWatch APIs.
+1. Confirm that you have access to [AWS CloudWatch APIs].
+   
+   The AWS Lambda Monitoring integration requires read-only access to AWS CloudWatch (e.g. `arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess`).
 
-   All forms of AWS authentication supported by the [AWS CLI] are supported, including [EC2 IAM Instance Profiles]. This integration requires read-only access to AWS CloudWatch (e.g. `arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess`).
+1. Get AWS authentication credentials.
+   
+   The AWS Lambda Monitoring integration accepts all forms of AWS authentication supported by the [AWS CLI]:
 
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secret(s) or environment variable(s) are not needed if the check(s) from this integration are run on a `sensu-agent` installed on an EC2 instance with an IAM Instance Profile containing the `arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess`.
+   - AWS credential profile
+   - AWS access key ID + AWS secret access key
+   - [EC2 IAM instance profile]
 
-[AWS CLI]: https://aws.amazon.com/cli/
-[EC2 IAM Instance Profiles]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+   Avoid providing an AWS credential profile, access key ID, or secret access key in production environments. We suggest an alternative form of AWS authentication, such as EC2 IAM instance profiles.
+
+   If the check from this integration will run on a Sensu agent installed on an EC2 instance whose EC2 IAM instance profile contains `arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess`, you do not need to provide an AWS credential profile, access key ID, or secret access key.
+
+   **Optional**: If you want to use Sensu [secrets] to represent the AWS profile name, access key ID, or secret access key, you will need the secret names when you install this integration.
+
+1. Decide which Sensu agents should execute the `aws-{AWS_REGION}-lambda-metrics` check. You will need the agent subscription names when you install this integration.
+
+1. If you want to use a Sensu [pipeline] to process AWS Lambda Monitoring integration data, you will need the pipeline names when you install this integration.
+
+   You can configure separate pipelines for alerts, incident management, and metrics.
+
+### Token substitution
+
+The AWS Lambda Monitoring integration supports Sensu [tokens] for variable substitution with data from Sensu entities.
 
 ## Plugins
 
 <!-- Links to any Sensu Integration dependencies (i.e. Sensu Plugins) -->
 
+The AWS Lambda Monitoring integration uses the following Sensu [plugins]:
+
 - [sensu/sensu-cloudwatch-check][sensu-cloudwatch-check-bonsai] ([GitHub][sensu-cloudwatch-check-github])
-
-## Metrics & Events
-
-<!-- List of all metrics or events collected by this integration. -->
-
-This integration collects dozens of [CloudWatch AWS Lambda metrics] (i.e. `AWS/Lambda` metrics).
-Please refer to the [Working with Lambda function metrics] reference documentation for descriptions of each metric, and [Important (Lambda) metrics for Cloudwatch] for recommended alerting thresholds.
-
-[Working with Lambda function metrics ]: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html
-[Important (Lambda) metrics for Cloudwatch]: https://docs.aws.amazon.com/lambda/latest/operatorguide/important-metrics.html
-
-| **Metric name** | **Tags** |
-|-----------------|----------|
-| **`aws_lambda_unreserved_concurrent_executions_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_unreserved_concurrent_executions_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_unreserved_concurrent_executions_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_concurrent_executions_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_concurrent_executions_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_concurrent_executions_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrent_executions_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrent_executions_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrent_executions_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrency_utilization_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrency_utilization_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrency_utilization_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_invocations`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_errors`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_dead_letter_errors`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_destination_delivery_failures`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_throttles`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrency_invocations`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_provisioned_concurrency_spillover_invocations`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_post_runtime_extensions_duration_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_post_runtime_extensions_duration_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_post_runtime_extensions_duration_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_iterator_age_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_iterator_age_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_iterator_age_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_offset_lag_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_offset_lag_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_offset_lag_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_duration_average`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_duration_maximum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
-| **`aws_lambda_duration_minimum`** | `FunctionName`, `Resource`, `Region`, `ExecutedVersion` |
 
 ## Alerts
 
 <!-- List of all alerts generated by this integration. -->
 
-This integration produces the following events which should be processed by an alert or incident management [pipeline]:
+The AWS Lambda Monitoring integration produces the following events that should be processed by an alert or incident management pipeline:
 
-* Errors
+**Errors**
 
-  <!-- Description of the alert condition. -->
+Generates a WARNING event when `aws_lambda_errors` is greater than a user-configurable maximum value (default 0).
 
-  A warning is generated when `aws_lambda_errors` is greater than a user-configurable minimum value (default: 0).
+**Throttles**
 
-* Throttles
+Generates a WARNING event when `aws_lambda_throttles` is greater than a user-configurable maximum value (default 0).
 
-  <!-- Description of the alert condition. -->
+**DeadLetterErrors**
 
-  A warning is generated when `aws_lambda_throttles` is greater than a user-configurable minimum value (default: 0).
+Generates a WARNING event when `aws_lambda_dead_letter_errors` is greater than a user-configurable maximum value (default 0).
+
+## Metrics
+
+<!-- List of all metrics or events collected by this integration. -->
+
+The AWS Lambda Monitoring integration collects dozens of CloudWatch AWS Lambda metrics (i.e. `AWS/Lambda` metrics), which are listed in the table below. For a description of each metric, read [Types of metrics] and [Important metrics for CloudWatch].
+
+Metric name | Tags
+----------- | ----
+`aws_lambda_unreserved_concurrent_executions_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_unreserved_concurrent_executions_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_unreserved_concurrent_executions_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_concurrent_executions_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_concurrent_executions_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_concurrent_executions_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrent_executions_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrent_executions_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrent_executions_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrency_utilization_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrency_utilization_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrency_utilization_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_invocations` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_errors` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_dead_letter_errors` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_destination_delivery_failures` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_throttles` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrency_invocations` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_provisioned_concurrency_spillover_invocations` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_post_runtime_extensions_duration_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_post_runtime_extensions_duration_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_post_runtime_extensions_duration_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_iterator_age_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_iterator_age_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_iterator_age_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_offset_lag_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_offset_lag_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_offset_lag_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_duration_average` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_duration_maximum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
+`aws_lambda_duration_minimum` | `FunctionName`, `Resource`, `Region`, `ExecutedVersion`
 
 ## Reference Documentation
 
 <!-- Please provide links to any relevant reference documentation to help users learn more and/or troubleshoot this integration; specifically including any third-party software documentation. -->
 
-1. This integration uses [Sensu Tokens][tokens] for variable substitution.
-1. [Important (Lambda) metrics for Cloudwatch](https://docs.aws.amazon.com/lambda/latest/operatorguide/important-metrics.html)
+[AWS Lambda] (AWS documentation)
+[Amazon CloudWatch API Reference][AWS CloudWatch APIs] (AWS documentation)
+
 
 <!-- Links -->
 [check]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/checks/
@@ -131,3 +146,10 @@ This integration produces the following events which should be processed by an a
 [{{dashboard-link}}]: #
 [sensu-cloudwatch-check-bonsai]: https://bonsai.sensu.io/assets/sensu/sensu-cloudwatch-check
 [sensu-cloudwatch-check-github]: https://github.com/sensu/sensu-cloudwatch-check
+[Types of metrics]: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html#monitoring-metrics-types
+[Important metrics for CloudWatch]: https://docs.aws.amazon.com/lambda/latest/operatorguide/important-metrics.html
+[AWS Lambda]: https://aws.amazon.com/lambda/
+[AWS CloudWatch]: https://aws.amazon.com/cloudwatch/
+[AWS CLI]: https://aws.amazon.com/cli/
+[EC2 IAM instance profile]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+[AWS CloudWatch APIs]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/Welcome.html

--- a/integrations/aws/aws-lambda-monitoring/sensu-integration.yaml
+++ b/integrations/aws/aws-lambda-monitoring/sensu-integration.yaml
@@ -26,24 +26,22 @@ spec:
       title: AWS Configuration
     - type: markdown
       body: |
-        Please provide the following configuration parameters:
+        Provide these AWS configuration parameters:
 
-        * AWS Region
-        * AWS Authentication (optional)<sup>*</sup>
-          * AWS Profile (optional)
-          * AWS Access Key ID (optional)
-          * AWS Secret Access Key (optional)
+        * AWS region
+        * AWS credential profile **OR** AWS access key ID + AWS secret access key
 
-        _NOTE: Providing an AWS Profile and/or AWS Access Key ID + AWS Secret Access Key authentication is strongly discouraged for production environments.
-        An alternative form of AWS Authentication such as EC2 IAM Instance Profiles is recommended._
+        Do not provide an AWS credential profile, access key ID, or secret access key in production environments. We suggest an alternative form of AWS authentication, such as EC2 IAM instance profiles.
+
+        If the check from this integration will run on a Sensu agent installed on an EC2 instance whose EC2 IAM instance profile contains `arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess`, you do not need to provide an AWS credential profile, access key ID, or secret access key.
     - type: question
       name: aws_region
       required: true
       input:
         type: string
-        title: AWS Region
+        title: AWS region
         description: >-
-          Select an AWS Region
+          Select an AWS region
         enum:
           - us-east-1
           - us-east-2
@@ -81,12 +79,10 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Profile
+                title: AWS credential profile name
                 const: none
                 constLocale:
-                  title: None
-                  description: >-
-                    Select this option to rely on pre-provisioned profile
+                  title: "-"
           - type: object
             required:
               - option
@@ -94,17 +90,17 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Profile
+                title: AWS credential profile name
                 const: secret
                 constLocale:
                   title: Secret
                   description: >-
-                    Select this option to use Sensu Secrets Management
+                    Use a Sensu secret to provide the profile name
               secret:
                 type: string
-                title: AWS Profile (Sensu Secret)
+                title: Secret name
                 description: >-
-                  Select the AWS Profile (Sensu Secret)
+                  Enter the secret name for the AWS credential profile name
                 ref: secrets/v1/secret/metadata/name
           - type: object
             required:
@@ -113,17 +109,17 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Profile
+                title: AWS credential profile name
                 const: env_var
                 constLocale:
-                  title: Environment Variable
+                  title: Environment variable
                   description: >-
-                    Select this option to store sensitive configuration as environment variables
+                    Save the AWS credential profile name as a backend environment variable
               env_var:
                 type: string
-                title: AWS Profile
+                title: AWS credential profile name
                 description: >-
-                  Provide the AWS Profile (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+                  Enter the AWS credential profile name (name will be stored in the Sensu API as unencrypted plaintext)
     - type: question
       name: aws_access_key_id
       input:
@@ -135,12 +131,10 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Access Key ID
+                title: AWS access key ID
                 const: none
                 constLocale:
-                  title: None
-                  description: >-
-                    Select this option to rely on pre-provisioned access key
+                  title: "-"
           - type: object
             required:
               - option
@@ -148,17 +142,17 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Access Key ID
+                title: AWS access key ID
                 const: secret
                 constLocale:
                   title: Secret
                   description: >-
-                    Select this option to use Sensu Secrets Management
+                    Use a Sensu secret to provide the AWS access key ID
               secret:
                 type: string
-                title: AWS Access Key ID (Sensu Secret)
+                title: Secret name
                 description: >-
-                  Select the AWS Access Key ID (Sensu Secret)
+                  Enter the secret name for the AWS access key ID
                 ref: secrets/v1/secret/metadata/name
           - type: object
             required:
@@ -167,17 +161,17 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Access Key ID
+                title: AWS access key ID
                 const: env_var
                 constLocale:
-                  title: Environment Variable
+                  title: Environment variable
                   description: >-
-                    Select this option to store sensitive configuration as environment variables
+                    Save the AWS access key ID as a backend environment variable
               env_var:
                 type: string
-                title: AWS Access Key ID
+                title: AWS access key ID
                 description: >-
-                  Provide the AWS Access Key ID (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+                  Enter the AWS access key ID (ID will be stored in the Sensu API as unencrypted plaintext)
     - type: question
       name: aws_secret_access_key
       input:
@@ -189,12 +183,10 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Secret Access Key
+                title: AWS secret access key
                 const: none
                 constLocale:
-                  title: None
-                  description: >-
-                    Select this option to rely on pre-provisioned secret access key
+                  title: "-"
           - type: object
             required:
               - option
@@ -202,17 +194,17 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Secret Access Key
+                title: AWS secret access key
                 const: secret
                 constLocale:
                   title: Secret
                   description: >-
-                    Select this option to use Sensu Secrets Management
+                    Use a Sensu secret to provide the AWS secret access key
               secret:
                 type: string
-                title: AWS Secret Access Key (Sensu Secret)
+                title: Secret
                 description: >-
-                  Select the AWS Secret Access Key (Sensu Secret)
+                  Enter the secret name for the AWS secret access key
                 ref: secrets/v1/secret/metadata/name
           - type: object
             required:
@@ -221,81 +213,81 @@ spec:
             properties:
               option:
                 type: string
-                title: AWS Secret Access Key
+                title: AWS secret access key
                 const: env_var
                 constLocale:
                   title: Environment Variable
                   description: >-
-                    Select this option to store sensitive configuration as environment variables
+                    Save the AWS secret access key as a backend environment variable
               env_var:
                 type: string
-                title: AWS Secret Access Key
+                title: AWS secret access key
                 description: >-
-                  Provide the AWS Secret Access Key (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+                  Enter the AWS secret access key (key will be stored in the Sensu API as unencrypted plaintext)
     - type: section
-      title: Configure Thresholds
+      title: Alerting Thresholds
     - type: markdown
       body: |
-        Configure alerting thresholds for:
+        Add alerting thresholds for:
 
-        * Maximum errors
-        * Maximum tolerable throttle events
-        * Maximum tolerable DeadLetterErrors
+        * Maximum number of errors
+        * Maximum number of throttle events
+        * Maximum number of dead letter errors
     - type: question
       name: aws_lambda_errors
       input:
         type: integer
-        title: Maximum allowed errors
+        title: Maximum number of errors
         description: >-
-          Configure the number of errors over which to warn.
+          Enter the maximum number of errors (default is `1`)
         default: 1
     - type: question
       name: aws_lambda_throttles
       input:
         type: integer
-        title: Maximum allowed throttle events
+        title: Maximum number of throttle events
         description: >-
-          Configure the number of throttle events over which to warn.
+          Enter the maximum number of throttle events (default is `0`)
         default: 0
     - type: question
       name: aws_lambda_dead_letter_errors
       input:
         type: integer
-        title: Maximum allowed DeadLetterErrors
+        title: Maximum number of DeadLetterErrors
         description: >-
-          Configure the DeadLetterErrors warning threshold.
+          Enter the maximum number of DeadLetterErrors (default is `0`)
         default: 0
     - type: section
-      title: Configure Sensu Subscriptions
+      title: Sensu Subscriptions
     - type: markdown
       body: |
-        Configure which Sensu Agent subscriptions this check should be run on.
+        Specify the subscriptions for Sensu agents that should execute the `aws-[[aws_region]]-lambda-metrics` check
     - type: question
       name: subscriptions
       input:
         type: array
         items:
           type: string
-          title: Sensu Subscriptions
+          title: Sensu subscriptions
           ref: core/v2/entity/subscriptions
         default:
           - aws
           - aws/lambda
     - type: section
-      title: Pipeline Configuration
+      title: Pipeline Configurations
     - type: markdown
       body: |
-        Configure one or more [pipelines] for processing AWS Lambda data.
+        Name the [pipelines] you want to use to process AWS Lambda Monitoring integration data.
 
-        [pipelines]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/
+        [pipelines]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
     - type: question
       name: alert_pipeline
       required: false
       input:
         type: string
-        title: Alert Pipeline
+        title: Alert pipeline name
         description: >-
-          How do you want to be alerted for failures detected by this pipeline (e.g. Slack or Microsoft Teams)?
+          Which pipeline do you want to use for alerts due to failures this integration detects?
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "alerts"
     - type: question
@@ -303,9 +295,9 @@ spec:
       required: false
       input:
         type: string
-        title: Incident Management Pipeline
+        title: Incident management pipeline name
         description: >-
-          How do you want to process incidents for failures detected by this pipeline (e.g. Atlassian JIRA/ServiceDesk, or Pagerduty)?
+          Which pipeline do you want to use to process incidents due to failures this integration detects?
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "incidents"
     - type: question
@@ -313,9 +305,9 @@ spec:
       required: false
       input:
         type: string
-        title: Metrics Pipeline
+        title: Metrics pipeline name
         description: >-
-          How do you want to process metrics collected by this integration?
+          Which pipeline do you want to use to process the metrics this integration collects?
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "metrics"
   resource_patches:
@@ -400,4 +392,6 @@ spec:
       title: Success
     - type: markdown
       body: |
-        The AWS Lambda monitoring integration was successfully installed for the `[[aws_region]]` AWS Region.
+        Success: You enabled the AWS Lambda Monitoring integration for the `[[aws_region]]` AWS region.
+
+        The `aws-[[aws_region]]-lambda-metrics` check will run for all Sensu agents with these subscriptions: [[subscriptions]].


### PR DESCRIPTION
Includes minor text revision in README, as well as these documented in the changelog:

- Revise text labels and prompts in configuration modal
- Remove "none" option for providing credentials for consistency among integrations
- Add summary for success screen in integration yaml file
- Add several setup steps and options in README
- Update README link references to match headings on the linked pages
- Add alert for aws_lambda_dead_letter_errors in README
- Reformat metrics table in README
- Add reference documentation list