### PR TITLE
Text updates: http/http-service-monitoring

### DIFF
--- a/integrations/http/http-service-monitoring/CHANGELOG.md
+++ b/integrations/http/http-service-monitoring/CHANGELOG.md
@@ -7,7 +7,13 @@ to [Semantic Versioning][semver].
 
 ## Unreleased
 
-- N/A
+- Revise text labels and prompts in configuration modal
+- Add default subscription (http)
+- Add interval patches in integration yaml
+- Add summary for success screen in integration yaml file
+- Reformat metrics table in README
+- Add several setup steps and options in README
+- Update README link references to match headings on the linked pages
 
 ## [ 20220421.0.0 ] - 2022-04-21
 

--- a/integrations/http/http-service-monitoring/README.md
+++ b/integrations/http/http-service-monitoring/README.md
@@ -2,14 +2,14 @@
 
 <!-- Sensu Integration description; supports markdown -->
 
-The HTTP Service monitoring integration provides healthchecks and performance monitoring for local HTTP services (e.g. a service running on a host or pod where an agent is deployed).
+The HTTP Service Monitoring (Local) integration provides healthchecks and performance monitoring for local HTTP services (e.g. a service running on a host or pod where an agent is deployed).
 
 <!-- Provide a high level overview of the integration contents (e.g. checks, filters, mutators, handlers, assets, etc) -->
 
-This integration includes the following resources:
+This integration includes the following Sensu resources:
 
-* `http-endpoint-monitoring` [check]
-* `http-endpoint-metrics` [check]
+* `{SERVICE_NAME}-http-service-monitoring` [check]
+* `{SERVICE_NAME}-http-service-metrics` [check]
 * `sensu/http-checks:0.5.0` [asset]
 
 ## Dashboards
@@ -20,18 +20,31 @@ This integration includes the following resources:
 
 <!-- ![](img/dashboard.png) -->
 
-There are no compatible dashboards for this integration.
+The HTTP Service Monitoring (Local) integration does not have compatible dashboards.
 
 ## Setup
 
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **[OPTIONAL] Disable redirect warnings**
+1. Get the local service URL. You will need these service URL elements to install this integration:
 
-   To disable redirect warnings, install this integration, then modify the resulting Sensu Check resource with the `--redirect-ok` flag.
+   - Protocol (`http` or `https`)
+   - Host (hostname, IP address, or domain name)
+   - Port number (e.g. `8080` for http or `443` for http)
+   - Path (e.g. `/healthz`)
 
-   Example:
+1. Decide which Sensu agents should execute the `{SERVICE_NAME}-http-service-healthcheck` and `{SERVICE_NAME}-http-service-metrics` checks. You will need the agent [subscription] names when you install this integration.
+
+1. If you want to use a Sensu [pipeline] to process HTTP Service Monitoring (Local) integration data, you will need the pipeline names when you install this integration.
+
+   You can configure separate pipelines for alerts, metrics, and incident management.
+
+1. **Optional** Disable redirect warnings.
+
+   To disable redirect warnings, install this integration. Then, update the `{SERVICE_NAME}-http-service-healthcheck` and `{SERVICE_NAME}-http-service-metrics` checks to add the `--redirect-ok` flag in the `command` attributes.
+
+   <details><summary><strong>Example: Check command with disabled redirect warnings</strong></summary>
 
    ```yaml
    spec:
@@ -42,21 +55,31 @@ There are no compatible dashboards for this integration.
        --url "http://127.0.0.1:8080/health"
    ```
 
-2. **[OPTIONAL] Configure custom request headers**
+   **NOTE**: The `{SERVICE_NAME}-http-service-healthcheck` check uses the `http-check` command as shown in the example. In the `{SERVICE_NAME}-http-service-metrics` check, the command uses `http-perf` instead.
 
-   To add custom request headers, install this integration, then modify the resulting Sensu Check resource with one or more `--header` flags.
+   </details>
+   <br>
 
-   Example:
+1. **Optional** Configure custom request headers.
+
+   To use custom request headers, install this integration. Then, update the `{SERVICE_NAME}-http-service-healthcheck` and `{SERVICE_NAME}-http-service-metrics` checks to add one or more `--header` flags in the `command` attributes.
+
+   <details><summary><strong>Example: Custom request header configuration</strong></summary>
 
    ```yaml
    spec:
      command: >-
        http-check
        --timeout 10
-       --url "http://127.0.0.1:8080/health
+       --url "http://127.0.0.1:8080/health"
        --header "Content-Type: application/json"
        --header "X-Example-Header: helloworld"
    ```
+
+   **NOTE**: The `{SERVICE_NAME}-http-service-healthcheck` check uses the `http-check` command as shown in the example. In the `{SERVICE_NAME}-http-service-metrics` check, the command uses `http-perf` instead.
+
+   </details>
+   <br>
 
 ## Plugins
 
@@ -64,41 +87,40 @@ There are no compatible dashboards for this integration.
 
 - [sensu/http-checks][http-checks-bonsai] ([GitHub][http-checks-github])
 
-## Metrics & Events
-
-<!-- List of all metrics or events collected by this integration. -->
-
-This integration collects the following [metrics]:
-
-| **Metric name** | **Description** | **Tags** |
-|-----------------|-----------------|----------|
-| `dns_duration` | Time to DNS resolution | `url` |
-| `tls_handshake_duration` | Time to TLS handshake | `url` |
-| `connect_duration` | Time to fetch HTTP contents | `url` |
-| `first_byte_duration` | Time to fetch first byte of HTTP content | `url` |
-| `total_request_duration` | Total time to complete request | `url` |
-
 ## Alerts
 
 <!-- List of all alerts generated by this integration. -->
 
-This integration produces the following events which should be processed by an alert or incident management [pipeline]:
+The HTTP Service Monitoring (Local) integration produces the following events that should be processed by an alert or incident management [pipeline]:
 
-* Request duration warning
+**Request duration warning**
 
-  Generates a warning if the `total_request_duration` exceeds the configured threshold (default: 1.0 seconds).
+Generates a WARNING event if the `total_request_duration` exceeds the user-configured threshold, in seconds (default 1).
 
-* Redirect warnings
+**Redirect warning**
 
-  Generates a warning for HTTP 3xx response codes (e.g. `WARNING: HTTP Status 301 for https://sumologic.com:443/  (redirects to https://www.sumologic.com:443/)`)
+Generates a WARNING event for HTTP 3xx response codes such as `WARNING: HTTP Status 301 for https://127.0.0.1:8080/health (redirects to http://127.0.0.1:8080/health)`.
 
-  <!-- Description of the alert condition. -->
+## Metrics
+
+<!-- List of all metrics or events collected by this integration. -->
+
+The HTTP Service Monitoring (Local) integration collects the following [metrics]:
+
+Metric name | Description | Tags
+----------- | ----------- | ----
+`dns_duration` | Time to DNS resolution | `url`
+`tls_handshake_duration` | Time to TLS handshake | `url`
+`connect_duration` | Time to fetch HTTP contents | `url`
+`first_byte_duration` | Time to fetch first byte of HTTP content | `url`
+`total_request_duration` | Total time to complete request | `url`
 
 ## Reference Documentation
 
 <!-- Please provide links to any relevant reference documentation to help users learn more and/or troubleshoot this integration; specifically including any third-party software documentation. -->
 
-1. This integration uses [Sensu Tokens][tokens] for variable substitution.
+* [Token substitution] (Sensu documentation): the HTTP Endpoint Monitoring (Remote) integration supports Sensu tokens for variable substitution with data from Sensu entities
+
 
 <!-- Links -->
 [entity]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-entities/entities/
@@ -114,7 +136,7 @@ This integration produces the following events which should be processed by an a
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
 [secret]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
 [secrets]: https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/
-[tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
+[Token substitution]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [sensu-plus]: https://sensu.io/features/analytics
 [http-checks-bonsai]: https://bonsai.sensu.io/assets/sensu/http-checks
 [http-checks-github]: https://github.com/sensu/http-checks

--- a/integrations/http/http-service-monitoring/sensu-integration.yaml
+++ b/integrations/http/http-service-monitoring/sensu-integration.yaml
@@ -8,7 +8,7 @@ spec:
   class: supported
   provider: monitoring
   display_name: HTTP Service Monitoring (Local)
-  short_description: "Local HTTP Service Monitoring"
+  short_description: Collect metrics and monitor health for local HTTP services
   supported_platforms:
     - darwin
     - linux
@@ -22,65 +22,65 @@ spec:
     - "@nizwiz"
   prompts:
     - type: section
-      title: HTTP Service Configuration
+      title: Local HTTP Service Configuration
     - type: markdown
       body: |
-        Configure HTTP Service monitoring with the following parameters:
+        Provide these configuration parameters for the local HTTP service:
 
-        * **App**: the name of the HTTP service (will be used as Sensu check/event name prefix)
-        * **URL**: the target URL to monitor (e.g. `http://localhost:80/health`)
-          * **Protocol**: select http or https request
-          * **Host**: provide a hostname, IP address, or domain name
-          * **Port**: provide the port to check (e.g. `80` for HTTP, `443` for HTTPS)
-          * **Path**: provide the URL path to check (e.g. `/healthz`)
-        * **Interval**: how often to monitor the HTTP service (in seconds)
-        * **Request Duration Warning**: generate a warning if requests take longer than N seconds to complete.
+        * Service name, which Sensu will use as the prefix for check and event names
+        * Local service URL to check and collect metrics from, such as `http://127.0.0.1:8080/health`, separated into:
+          * Protocol (`http` or `https`)
+          * Host (hostname, IP address, or domain name)
+          * Port number (e.g. `8080` for http or `443` for http)
+          * Path (e.g. `/healthz`)
+        * Interval for checking and collecting metrics from the service (in seconds)
+        * Alerting threshold for request duration
     - type: question
       name: app
       required: true
       input:
         type: string
-        title: App Name
+        title: Service name
         description: >-
-          Provide an application name for the HTTP service (e.g. "api").
+          Enter the name for the HTTP service
     - type: question
       name: protocol
       required: true
       input:
         type: string
-        title: HTTP Service Protocol
+        title: Local HTTP service protocol
         description: >-
-          Provide the HTTP service protocol (i.e. "http" or "https").
+          Select the protocol for the local HTTP service URL (`http` or `https`)
         enum:
           - http
           - https
-        default: https
+        default: http
     - type: question
       name: host
       required: true
       input:
         type: string
-        title: HTTP Service Host
+        title: Local HTTP service host
         description: >-
-          Provide the HTTP service host (this should usually be "localhost" or "127.0.0.1").
+          Enter the host for the local HTTP service URL (e.g. `localhost` or `127.0.0.1`)
         default: "127.0.0.1"
     - type: question
       name: port
       required: true
       input:
         type: integer
-        title: HTTP Service Port
+        title: Local HTTP service port
         description: >-
-          Provide the HTTP service port
+          Enter the port for the local HTTP service URL (e.g. `8080` for http or `443` for http)
         default: 8080
     - type: question
       name: path
       required: true
       input:
         type: string
-        title: HTTP Service Path
+        title: Local HTTP service path
         description: >-
-          Provide the HTTP service path (e.g. "/health"; NOTE: this configuration MUST begin with a "/")
+          Enter the path for the local HTTP service URL (MUST begin with `/`)
         default: "/"
     - type: question
       name: interval
@@ -88,54 +88,55 @@ spec:
         type: integer
         title: Interval
         description: >-
-          Configure the HTTP service monitoring interval, in seconds (60 = one minute, 300 = five minutes, 600 = 10 minutes, etc)
+          Specify the local HTTP service monitoring interval, in seconds (60 = 1 minute, 300 = 5 minutes, 600 = 10 minutes)
         default: 30
     - type: question
       name: duration_warning
       input:
         type: integer
-        title: Request Duration Warning
+        title: Maximum request duration
         description: >-
-          Generate a warning if requests take longer than N seconds to complete.
+          Enter the maximum request duration to allow before sending a WARNING event (default is `1`)
         default: 1
     - type: question
       name: labels
       input:
         type: object
-        title: Labels
-        description: Key/value metadata
+        title: Check labels
+        description: Add metadata labels for the checks
         format: io.sensu.meta.label
         additionalProperties:
           type: string
     - type: section
-      title: Configure Sensu Subscriptions
+      title: Sensu Subscriptions
     - type: markdown
       body: |
-        Configure which Sensu Agent subscriptions this check should be run on.
+        Specify the subscriptions for Sensu agents that should execute the `[[app]]-[[protocol]]-service-healthcheck` and `[[app]]-[[protocol]]-service-metrics` checks
     - type: question
       name: subscriptions
       input:
         type: array
         items:
           type: string
-          title: Subscriptions (Origins)
+          title: Subscriptions
           ref: core/v2/entity/subscriptions
-        default: []
+        default:
+          - http
     - type: section
       title: Pipeline Configuration
     - type: markdown
       body: |
-        Configure one or more [pipelines] for processing HTTP Status Monitoring data.
+        Name the [pipelines] you want to use to process HTTP Service Monitoring (Local) integration data.
 
-        [pipelines]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/
+        [pipelines]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
     - type: question
       name: alert_pipeline
       required: false
       input:
         type: string
-        title: Alert Pipeline
+        title: Alert pipeline name
         description: >-
-          How do you want to be alerted for failures detected by this pipeline (e.g. Slack or Microsoft Teams)?
+          Which pipeline do you want to use for alerts due to failures this integration detects?
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "alerts"
     - type: question
@@ -143,9 +144,9 @@ spec:
       required: false
       input:
         type: string
-        title: Incident Management Pipeline
+        title: Incident management pipeline name
         description: >-
-          How do you want to process incidents for failures detected by this pipeline (e.g. Atlassian JIRA/ServiceDesk, or Pagerduty)?
+          Which pipeline do you want to use to process incidents due to failures this integration detects?
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "incidents"
     - type: question
@@ -153,9 +154,9 @@ spec:
       required: false
       input:
         type: string
-        title: Metrics Pipeline
+        title: Metrics pipeline name
         description: >-
-          How do you want to process metrics collected by this integration?
+          Which pipeline do you want to use to process the metrics this integration collects?
         ref: core/v2/pipeline/metadata/name
         refFilter: .labels.provider == "metrics"
   resource_patches:
@@ -176,6 +177,9 @@ spec:
             http-check
             --timeout 10
             --url "[[protocol]]://[[host]]:[[port]][[path]]"
+        - op: replace
+          path: /spec/interval
+          value: interval
         - op: replace
           path: /spec/subscriptions
           value: subscriptions
@@ -209,6 +213,9 @@ spec:
             --timeout 10
             --url "[[protocol]]://[[host]]:[[port]][[path]]"
         - op: replace
+          path: /spec/interval
+          value: interval
+        - op: replace
           path: /spec/subscriptions
           value: subscriptions
         - op: replace
@@ -225,3 +232,11 @@ spec:
             api_version: core/v2
             type: Pipeline
             name: "[[metrics_pipeline]]"
+  post_install:
+    - type: section
+      title: Success
+    - type: markdown
+      body: |
+        You enabled the HTTP Service Monitoring (Local) integration.
+
+        The `[[app]]-[[protocol]]-service-healthcheck` and `[[app]]-[[protocol]]-service-metrics` checks will run for all Sensu agents with these subscriptions: [[subscriptions]].


### PR DESCRIPTION
Includes minor text revision in README, as well as these documented in the changelog:

- Revise text labels and prompts in configuration modal
- Add default subscription (http)
- Add interval patches in integration yaml
- Add summary for success screen in integration yaml file
- Reformat metrics table in README
- Add several setup steps and options in README
- Update README link references to match headings on the linked pages