### PR TITLE
Text updates: servicenow/servicenow-cmdb-registration

### DIFF
--- a/integrations/servicenow/servicenow-cmdb-registration/CHANGELOG.md
+++ b/integrations/servicenow/servicenow-cmdb-registration/CHANGELOG.md
@@ -7,7 +7,10 @@ to [Semantic Versioning][semver].
 
 ## Unreleased
 
-- N/A
+- Revise text labels and prompts in configuration modal
+- Revise summary for success and remove second screen in integration yaml file
+- Add and revise setup steps and options in README
+- Revise and add to reference documentation list in README
 
 ## [ 20220421.0.0 ] - 2022-04-21
 

--- a/integrations/servicenow/servicenow-cmdb-registration/README.md
+++ b/integrations/servicenow/servicenow-cmdb-registration/README.md
@@ -2,28 +2,24 @@
 
 <!-- Sensu Integration description; supports markdown -->
 
-The ServiceNow CMDB Registration integration provides automated registration of discovered Sensu Entities as ServiceNow CMDB Configuration Items.
+The ServiceNow CMDB Registration integration automatically registers Sensu entities as ServiceNow configuration management database (CMDB) Configuration Items (CIs).
 
-This integration will create/update ServiceNow CMDB Configuration Items.
-It supports custom CMDB tables and custom CMDB fields, with per-host configuration overrides.
-See the Setup section below for more information.
-
-This integration is compatible with ServiceNow versions "Rome" or older.
+This integration is compatible with ServiceNow versions **Rome and older**.
 
 <!-- Provide a high level overview of the integration contents (e.g. checks, filters, mutators, handlers, assets, etc) -->
 
-This integration includes the following resources:
+This integration includes the following Sensu resources:
 
-* `servicenow-cmdb` [pipeline]
 * `servicenow-cmdb` [handler]
 * `discovery-only` [filter]
+* `servicenow-cmdb` [pipeline]
 * `sensu/sensu-servicenow-handler:3.0.0` [asset]
 
 ## Dashboards
 
 <!-- List of compatible dashboards w/ screenshots (supports png, jpeg, and gif images; relative paths only; e.g. `![](img/dashboard-1.png)` )-->
 
-This integration is compatible with ServiceNow CMDB dashboards.
+The ServiceNow CMDB Registration integration is compatible with ServiceNow CMDB dashboards.
 
 ![](img/cmdb-dashboard.png)
 
@@ -32,20 +28,38 @@ This integration is compatible with ServiceNow CMDB dashboards.
 <!-- Sensu Integration setup instructions, including Sensu agent configuration and external component configuration -->
 <!-- EXAMPLE: what configuration (if any) is required in a third-party service to enable monitoring? -->
 
-1. **Enable ServiceNow CMDB registration using `--keepalive-handlers`**
+1. Get the ServiceNow instance's base URL (e.g. https://mycompany.service-now.com), username, and password.
 
-   To enable ServiceNow CMDB registration for all entities, configure the `--keepalive-handlers=servicenow-cmdb` flag, or modify `backend.yml` with the following contents, then restart the Sensu backend(s):
+   **Optional**: If you want to use Sensu [secrets] to represent the ServiceNow username and password, you will need the secret names when you install this integration.
+
+1. If your organization has a customized ServiceNow instance, get the following configuration information:
+
+    - Name of the ServiceNow CMDB table to use for managing CIs
+    - Field name that Sensu should use to look up CIs (the CMDB key)
+    - [Handler templates][handler-templating] for CI and asset tag naming
+    - Custom CI properties to populate from Sensu entity [annotations]
+
+    **NOTE**: If you are using an unmodified ServiceNow instance, the installation steps for this integration include default configuration details. You do not need custom configuration to use this integration.
+
+1. Enable ServiceNow CMDB registration by specifying an agent keepalive handler or a check pipeline reference.
+
+   <details><summary><strong>Example: Agent keepalive handler configuration</strong></summary>
+
+   To enable ServiceNow CMDB registration for all entities, list the `servicenow-cmdb` handler as a value for the [keepalive-handlers] agent configuration option in the `agent.yml` configuration file:
 
    ```yaml
    keepalive-handlers:
      - servicenow-cmdb
    ```
 
-   _NOTE: in clustered deployments, you will need to configure & restart every Sensu backend for [`keepalive-handlers` configuration][keepalive-handlers] to take effect._
+   **NOTE**: You must [restart] the Sensu agent for the keepalive handler configuration to take effect.
 
-   Alternatively, checks configured with the `servicenow-cmdb` [pipeline] may be used to enable CMDB registration.
+   </details>
+   <br>
+   
+   <details><summary><strong>Example: Check pipeline reference configuration</strong></summary>
 
-   Example:
+   To enable ServiceNow CMDB registration only for entities that execute a specific check, add the `servicenow-cmdb` [pipeline] to the check definition.
 
    ```yaml
    spec:
@@ -55,13 +69,14 @@ This integration is compatible with ServiceNow CMDB dashboards.
          name: servicenow-cmdb
    ```
 
-   [keepalive-handlers]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handlers/#keepalive-event-handlers
+   </details>
+   <br>
 
-1. **[OPTIONAL] Customize ServiceNow CMDB configuration on a per-host basis**
+1. **Optional** Specify custom ServiceNow CMDB configuration on a per-entity or per-check basis.
 
-   Sensu Entity annotations may be used to override the default ServiceNow CMDB integration configuration.
+   <details><summary><strong>Example: Custom CMDB table and asset tag configuration</strong></summary>
 
-   Examples:
+   The ServiceNow CMDB Registration integration uses the configuration parameters you specify during installation. To override the installed configuration for a single entity or check, add [annotations] with the prefix `servicenow/config/` to the `agent.yml` configuration file or the check definition.
 
    ```yaml
    annotations:
@@ -69,17 +84,22 @@ This integration is compatible with ServiceNow CMDB dashboards.
      servicenow/config/cmdb-asset-tag: "aws/us-west-2/instances/i-424242"
    ```
 
-   For more information, please visit the [ServiceNow Handler "Annotations" reference documentation].
+   For a complete list of available annotations, read the [sensu/sensu-servicenow-handler annotations documentation].
 
-2. **[OPTIONAL] Customize ServiceNow CMDB Configuration Item properties**
+   </details>
+   <br>
 
-   This integration supports custom ServiceNow CMDBs tables with custom fields.
-   To enable custom fields set the `--cmdb-properties` flag (e.g. `--cmdb-properties asset_tag,store_id`).
-   _NOTE: The integration installation wizard will prompt you for a list of custom fields._
+1. **Optional** Configure custom ServiceNow CMDB CI properties.
 
-   Once enabled, custom properties can be set on a per-host basis using `servicenow/table/cmdb/<fieldname>` Entity annotations.
+   <details><summary><strong>Example: Custom ServiceNow CMDB CI property configuration</strong></summary>
 
-   Example `agent.yml` (assuming `--cmdb-properties: asset_tag,store_id`):
+   The ServiceNow CMDB Registration integration supports ServiceNow CMDB tables with custom fields.
+
+   When you install this integration, you can list custom CI properties to populate from Sensu entity [annotations] with the prefix `servicenow/table/cmdb/`. If an entity includes a matching annotation, Sensu will populate the corresponding field in the ServiceNow CMDB table with the annotation's value.
+
+   For example, if you list the `asset_tag` and `store_id` custom CI properties when you install this integration, Sensu will check entities for matching annotations.
+
+   Set the entity annotations in the `agent.yml` configuration file:
 
    ```yaml
    annotations:
@@ -87,20 +107,23 @@ This integration is compatible with ServiceNow CMDB dashboards.
      servicenow/table/cmdb/store_id: "1234"
    ```
 
-[Sensu Entity]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-entities/entities/
-[ServiceNow Handler "Annotations" reference documentation]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler#annotations
+   To add custom CI properties after installing this integration, update the `servicenow-cmdb` handler command to list the additional properties in the `--cmdb-properties` flag values:
+
+   ```yaml
+   command: >-
+    sensu-servicenow-handler --cmdb-registration --cmdb-table cmdb_ci --cmdb-key name --cmdb-name "{{ .Entity.Name }}" --cmdb-asset-tag "sensu/{{ .Entity.Namespace }}/{{ .Entity.Name }}" --cmdb-properties "asset_tag,store_id,category,location"
+   ```
+
+   </details>
+   <br>
 
 ## Plugins
 
 <!-- Links to any Sensu Integration dependencies (i.e. Sensu Plugins) -->
 
+The ServiceNow CMDB Registration integration uses the following Sensu [plugins]:
+
 - [sensu/sensu-servicenow-handler][sensu-servicenow-handler-bonsai]
-
-## Metrics & Events
-
-<!-- List of all metrics or events collected by this integration. -->
-
-This integration does not produce any [metrics].
 
 ## Alerts
 
@@ -108,13 +131,21 @@ This integration does not produce any [metrics].
 
 <!-- This integration provides an alert & incident management processing pipeline for use with other monitoring integrations. By default this integration will process all events passing the [built-in `is_incident` filter][is_incident] (i.e. failing events and resolution events only). Event processing via this integration may be suppressed using [Sensu Silencing][silences] (see the [built-in `not_silenced` filter][not_silenced] for more details). -->
 
-This integration does not produce any events that should be processed by an alert or incident management [pipeline].
+The ServiceNow CMDB Registration integration does not produce any events that should be processed by an alert or incident management [pipeline].
+
+## Metrics
+
+<!-- List of all metrics or events collected by this integration. -->
+
+The ServiceNow CMDB Registration integration does not produce any [metrics].
 
 ## Reference Documentation
 
 <!-- Please provide links to any relevant reference documentation to help users learn more and/or troubleshoot this integration; specifically including any third-party software documentation. -->
 
-1. This integration uses [Handler Templating][handler-templating] for variable substitution.
+* [Handler templating][handler-templating] (Sensu documentation): the ServiceNow CMDB Registration integration supports handler templating for variable substitution with data from Sensu events
+* [Configuration Management Database][servicenow-cmdb] (ServiceNow documentation)
+
 
 <!-- Links -->
 [check]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/checks/
@@ -122,7 +153,8 @@ This integration does not produce any events that should be processed by an aler
 [subscription]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/subscriptions/
 [subscriptions]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/subscriptions/
 [agents]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/
-[annotation]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[annotation]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#agent-annotations
+[annotations]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#agent-annotations
 [plugins]: https://docs.sensu.io/sensu-go/latest/plugins/
 [metrics]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/metrics/
 [pipeline]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/pipelines/
@@ -134,6 +166,8 @@ This integration does not produce any events that should be processed by an aler
 [tokens]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/tokens/
 [handler-templating]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
 [sensu-plus]: https://sensu.io/features/analytics
-[{{dashboard-link}}]: #
 [sensu-servicenow-handler-bonsai]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler
-
+[servicenow-cmdb]: https://docs.servicenow.com/bundle/rome-servicenow-platform/page/product/configuration-management/concept/c_ITILConfigurationManagement.html
+[restart]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#restart-the-service
+[keepalive-handlers]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#keepalive-handlers-option
+[sensu/sensu-servicenow-handler annotations documentation]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler#annotations

--- a/integrations/servicenow/servicenow-cmdb-registration/sensu-integration.yaml
+++ b/integrations/servicenow/servicenow-cmdb-registration/sensu-integration.yaml
@@ -8,7 +8,7 @@ spec:
   class: enterprise
   provider: discovery
   display_name: ServiceNow CMDB Registration
-  short_description: Create and update Configuration Items in the ServiceNow CMDB
+  short_description: Automatically register Sensu entities as ServiceNow CMDB Configuration Items
   supported_platforms:
     - darwin
     - linux
@@ -26,20 +26,16 @@ spec:
       title: ServiceNow Instance Configuration
     - type: markdown
       body: |
-        This integration requires the following ServiceNow configuration:
-
-        * ServiceNow URL (e.g. `https://mycompany.service-now.com`)
-        * ServiceNow Username
-        * ServiceNow Password
+        Specify the ServiceNow instance URL, username, and password.
     - type: question
       name: servicenow_url
       required: true
       input:
         type: string
         format: url
-        title: ServiceNow URL
+        title: ServiceNow instance base URL
         description:
-          Provide the base URL of your ServiceNow instance (e.g. "https://mycompany.service-now.com")
+          Enter the ServiceNow intance base URL
         default: https://mycompany.service-now.com
     - type: question
       name: servicenow_username
@@ -54,17 +50,17 @@ spec:
             properties:
               option:
                 type: string
-                title: ServiceNow Username
+                title: ServiceNow username
                 const: secret
                 constLocale:
                   title: Secret
                   description: >-
-                    Select this option to use Sensu Secrets Management
+                    Use a Sensu secret to provide the ServiceNow username
               secret:
                 type: string
-                title: ServiceNow Username (Sensu Secret)
+                title: Secret name
                 description: >-
-                  Select the ServiceNow username (Sensu Secret)
+                  Enter the secret name for the ServiceNow username
                 ref: secrets/v1/secret/metadata/name
           - type: object
             required:
@@ -76,14 +72,14 @@ spec:
                 title: ServiceNow Username
                 const: env_var
                 constLocale:
-                  title: Environment Variable
+                  title: Environment uariable
                   description: >-
-                    Select this option to store sensitive configuration as environment variables
+                    Save the ServiceNow username as a backend environment variable
               env_var:
                 type: string
-                title: ServiceNow Username
+                title: ServiceNow username
                 description: >-
-                  Provide the ServiceNow username (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+                  Enter the ServiceNow username (username will be stored in the Sensu API as unencrypted plaintext)
     - type: question
       name: servicenow_password
       required: true
@@ -97,17 +93,17 @@ spec:
             properties:
               option:
                 type: string
-                title: ServiceNow Password
+                title: ServiceNow password
                 const: secret
                 constLocale:
                   title: Secret
                   description: >-
-                    Select this option to use Sensu Secrets Management
+                    Use a Sensu secret to provide the ServiceNow password
               secret:
                 type: string
-                title: ServiceNow Password (Sensu Secret)
+                title: Secret name
                 description: >-
-                  Select the ServiceNow password (Sensu Secret)
+                  Enter the secret name for the ServiceNow password
                 ref: secrets/v1/secret/metadata/name
           - type: object
             required:
@@ -116,30 +112,30 @@ spec:
             properties:
               option:
                 type: string
-                title: ServiceNow Password
+                title: ServiceNow password
                 const: env_var
                 constLocale:
-                  title: Environment Variable
+                  title: Environment variable
                   description: >-
-                    Select this option to store sensitive configuration as environment variables
+                    Save the ServiceNow password as a backend environment variable
               env_var:
                 type: string
-                title: ServiceNow Password
+                title: ServiceNow password
                 description: >-
-                  Provide the ServiceNow password (NOTE: this will be stored in the Sensu API as unencrypted plaintext).
+                  Enter the ServiceNow password (password will be stored in the Sensu API as unencrypted plaintext)
     - type: section
       title: ServiceNow Customizations
     - type: markdown
       body: |
-        This integration is configured with default values that should "just work" with unmodified ServiceNow instances.
 
-        If your organization has a customized ServiceNow instance, please provide the following configuration parameters to customize the integration:
+        If your organization has a customized ServiceNow instance, provide the following configuration information to customize this integration:
 
-        * Default CMDB Table (which table Sensu should use for CMDB integration)
-        * Default CMDB Key (fieldname used to lookup CIs)
-        * Default CMDB Name ([handler template] for naming CIs in the CMDB)
-        * Default CMDB Asset Tag ([handler template] for setting CI asset tags)
-        * CMDB Properties (comma-separated list of additional/custom fields)
+        * Name of the ServiceNow CMDB table to use for managing Configuration Items (CIs)
+        * CMDB key: the field name that Sensu should use to look up CIs
+        * [Handler templates] for CI and asset tag naming
+        * Custom CI properties to populate from Sensu entity annotations
+
+        If you do not have a customized ServiceNow instance, the default values will work with unmodified ServiceNow instances.
 
         [handler template]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/handler-templates/
     - type: question
@@ -147,47 +143,46 @@ spec:
       required: true
       input:
         type: string
-        title: Default CMDB Table
+        title: CMDB table
         description: >-
-          Provide the ServiceNow table to use for managing Configuration Items.
+          Enter the name of the ServiceNow table to use for managing CIs.
         default: cmdb_ci
     - type: question
       name: servicenow_cmdb_key
       required: true
       input:
         type: string
-        title: Default CMDB Key
+        title: CMDB key
         description: >-
-          Provide the fieldname Sensu should use to lookup Configuration Items; effectively used as a "primary key".
+          Enter the CMDB key (the field name Sensu should use to look up CIs)
         default: name
     - type: question
       name: servicenow_cmdb_name
       required: true
       input:
         type: string
-        title: Default CMDB Name (Template)
+        title: CMDB naming template
         description: >-
-          Provide a handler template for generating the name of the CMDB Configuration Item to be created or updated.
+          Enter the handler template to use to generate CI names
         default: "{{ .Entity.Name }}"
     - type: question
       name: servicenow_cmdb_asset_tag
       required: true
       input:
         type: string
-        title: Default CMDB Asset Tag (Template)
+        title: CMDB asset tag template
         description: >-
-          Provide a handler template for generating the CMDB Configuration Item asset tag.
+          Enter the handler template to use to generate CI asset tags
         default: "sensu/{{ .Entity.Namespace }}/{{ .Entity.Name }}"
     - type: question
       name: servicenow_cmdb_properties
       required: true
       input:
         type: string
-        title: CMDB Properties
+        title: Custom CI properties
         description: >-
-          Provide a comma-separated list of custom properties to populate from Entity annotations (e.g. "asset_tag,category").
+          Enter a comma-separated list of custom CI properties to populate from Sensu entity annotations
         default: asset_tag
-
   resource_patches:
     - resource:
         api_version: core/v2
@@ -228,9 +223,16 @@ spec:
       title: Success
     - type: markdown
       body: |
-        You have successfully installed the ServiceNow CMDB Registration integration.
+        You enabled the ServiceNow CMDB Registration integration.
 
-        Checks configured with the `servicenow-cmdb` pipeline will send Sensu event and metric data to [[ servicenow_url ]].
+        To enable ServiceNow CMDB registration for all entities, list the `servicenow-cmdb` handler as a keepalive handler in the `agent.yml` configuration file:
+
+        ```yaml
+        keepalive-handlers:
+          - servicenow-cmdb
+        ```
+
+        To enable ServiceNow CMDB registration only for entities that execute a specific check, add the `servicenow-cmdb` pipeline to the check definition:
 
         ```yaml
         spec:
@@ -238,19 +240,4 @@ spec:
             - api_version: core/v2
               type: Pipeline
               name: servicenow-cmdb
-        ```
-    - type: section
-      title: Using Custom Properties
-    - type: markdown
-      body: |
-        This integration supports overriding various fields (`[[servicenow_cmdb_properties]]`) using custom property annotations.
-
-        To set these properties on a per-host basis, add `servicenow/table/cmdb/<fieldname>` annotations.
-
-        Example `agent.yml` (assuming `--cmdb-properties: asset_tag,store_id`):
-
-        ```yaml
-        annotations:
-          servicenow/table/cmdb/asset_tag: "i-424242"
-          servicenow/table/cmdb/store_id: "1234"
         ```


### PR DESCRIPTION
Includes minor text revision in README, as well as these documented in the changelog:

- Revise text labels and prompts in configuration modal
- Revise summary for success and remove second screen in integration yaml file
- Add and revise setup steps and options in README
- Revise and add to reference documentation list in README